### PR TITLE
Fix permissions for CloudWatch stop_query operation

### DIFF
--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -262,7 +262,6 @@ Resources:
                   - "logs:Get*"
                   - "logs:List*"
                   - logs:StartQuery
-                  - logs:StopQuery
                   - logs:FilterLogEvents
                 Effect: Allow
                 Resource:


### PR DESCRIPTION
`logs:StopQuery` needs to be granted for all log-groups as queries can include multiple log groups (docs for start_query [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/start_query.html)).