### PR TITLE
Updated `CloudAccountId` parameter to remove the list of allowed values

### DIFF
--- a/templates/cloudformation/aws_agent_with_basic_vpc.yaml
+++ b/templates/cloudformation/aws_agent_with_basic_vpc.yaml
@@ -25,9 +25,8 @@ Metadata:
 Parameters:
   CloudAccountId:
     Description: >
-      For deployments on the V2 Platform (not using a single-tenant deployment), use 590183797493. 
-      Accounts created after April 24th, 2024, will automatically be on the V2 platform or newer. 
-      If you are using an older version of the platform, or using a single-tenant deployment, 
+      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
+      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
       please contact your Monte Carlo representative for the ID.
     Type: String
     Default: 590183797493

--- a/templates/cloudformation/aws_agent_with_basic_vpc.yaml
+++ b/templates/cloudformation/aws_agent_with_basic_vpc.yaml
@@ -25,12 +25,12 @@ Metadata:
 Parameters:
   CloudAccountId:
     Description: >
-      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
-      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
+      For deployments on the V2 Platform (not using a single-tenant deployment), use 590183797493. 
+      Accounts created after April 24th, 2024, will automatically be on the V2 platform or newer. 
+      If you are using an older version of the platform, or using a single-tenant deployment, 
       please contact your Monte Carlo representative for the ID.
     Type: String
     Default: 590183797493
-    AllowedValues: [ 190812797848, 799135046351, 682816785079, 637423407294, 590183797493 ]
   ConcurrentExecutions:
     Default: 20
     Description: The number of concurrent lambda executions for the agent.

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -56,9 +56,8 @@ Metadata:
 Parameters:
   CloudAccountId:
     Description: >
-      For deployments on the V2 Platform (not using a single-tenant deployment), use 590183797493. 
-      Accounts created after April 24th, 2024, will automatically be on the V2 platform or newer. 
-      If you are using an older version of the platform, or using a single-tenant deployment, 
+      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
+      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
       please contact your Monte Carlo representative for the ID.
     Type: String
     Default: '590183797493'

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -56,12 +56,12 @@ Metadata:
 Parameters:
   CloudAccountId:
     Description: >
-      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
-      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
+      For deployments on the V2 Platform (not using a single-tenant deployment), use 590183797493. 
+      Accounts created after April 24th, 2024, will automatically be on the V2 platform or newer. 
+      If you are using an older version of the platform, or using a single-tenant deployment, 
       please contact your Monte Carlo representative for the ID.
     Type: String
     Default: '590183797493'
-    AllowedValues: [ '190812797848', '799135046351', '682816785079', '637423407294', '590183797493' ]
   ConcurrentExecutions:
     Default: 42
     Description: The number of concurrent lambda executions for the agent.

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -207,7 +207,7 @@ Resources:
           MCD_STORAGE_BUCKET_NAME: !Ref Storage
           MCD_AGENT_IS_REMOTE_UPGRADABLE: !If [ ShouldCreateUpdatePolicy, True, False ]
           MCD_AGENT_WRAPPER_TYPE: CLOUDFORMATION
-          MCD_AGENT_WRAPPER_VERSION: 1.0.0
+          MCD_AGENT_WRAPPER_VERSION: 1.0.1
           MCD_STACK_ID: !Ref 'AWS::StackId'
           MCD_LOG_GROUP_ID: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${AWS::Partition}/lambda/${AWS::StackName}-AgentLambda"
           MCD_AGENT_CONNECTED_TO_A_VPC: !If [ ShouldConnectVPC, True, False ]

--- a/templates/cloudformation/aws_data_store.yaml
+++ b/templates/cloudformation/aws_data_store.yaml
@@ -31,9 +31,8 @@ Metadata:
 Parameters:
   MonteCarloCloudAccountId:
     Description: >
-      For deployments on the V2 Platform (not using a single-tenant deployment), use 590183797493. 
-      Accounts created after April 24th, 2024, will automatically be on the V2 platform or newer. 
-      If you are using an older version of the platform, or using a single-tenant deployment, 
+      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
+      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
       please contact your Monte Carlo representative for the ID.
     Type: String
     Default: 590183797493

--- a/templates/cloudformation/aws_data_store.yaml
+++ b/templates/cloudformation/aws_data_store.yaml
@@ -31,12 +31,12 @@ Metadata:
 Parameters:
   MonteCarloCloudAccountId:
     Description: >
-      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
-      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
+      For deployments on the V2 Platform (not using a single-tenant deployment), use 590183797493. 
+      Accounts created after April 24th, 2024, will automatically be on the V2 platform or newer. 
+      If you are using an older version of the platform, or using a single-tenant deployment, 
       please contact your Monte Carlo representative for the ID.
     Type: String
     Default: 590183797493
-    AllowedValues: [ 190812797848, 799135046351, 682816785079, 637423407294, 590183797493 ]
 Conditions:
   ShouldSkipCloudAccountPolicy: !Equals
     - !Ref 'MonteCarloCloudAccountId'

--- a/templates/cloudformation/aws_generic_agent_ecs.yaml
+++ b/templates/cloudformation/aws_generic_agent_ecs.yaml
@@ -102,6 +102,8 @@ Resources:
               Value: !Ref TaskDefinitionImage
             - Name: "MCD_AGENT_WRAPPER_TYPE"
               Value: "CLOUDFORMATION"
+            - Name: "MCD_AGENT_WRAPPER_VERSION"
+              Value: "1.0.1"
             - Name: "MCD_AGENT_IS_REMOTE_UPGRADABLE"
               Value: "false"
             - Name: "PORT"


### PR DESCRIPTION
- Updated `CloudAccountId` parameter to remove the list of allowed values, accepting any account id