### PR TITLE
chore: add ingress rule for otel collector

### DIFF
--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -172,6 +172,15 @@ Resources:
                 aws:SecureTransport:
                   - false
     Type: AWS::S3::BucketPolicy
+  OpenTelemetryCollectorIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt OpenTelemetryCollector.Outputs.OpenTelemetryCollectorSecurityGroupId
+      IpProtocol: tcp
+      FromPort: 4317
+      ToPort: 4318
+      CidrIp: 0.0.0.0/0
+      Description: Allow TCP ingress on ports 4317 and 4318 from all IPs within the VPC
 Outputs:
   StorageBucketName:
     Description: Name of the S3 bucket used by the Agent and OpenTelemetry Collector to store data sampling records and telemetry data.

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -71,14 +71,14 @@ Parameters:
     Description: AWS Principal (ARN or account ID) allowed to assume the OpenTelemetry Collector external access role. If left empty, will use the current AWS account ID. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery)
     Type: String
     Default: "N/A"
-    AllowedPattern: '^(|[0-9]{12}|arn:aws:.*:.*)$'
-    ConstraintDescription: Must be either empty, a 12-digit AWS account ID, or a valid AWS ARN
+    AllowedPattern: '^(|N/A|[0-9]{12}|arn:aws:.*:.*)$'
+    ConstraintDescription: Must be either empty, N/A, a 12-digit AWS account ID, or a valid AWS ARN
   OpenTelemetryCollectorExternalNotificationChannelArn:
     Description: SQS Queue ARN to receive S3 event notifications for telemetry data. If left empty, no notifications will be configured. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery).
     Type: String
     Default: "N/A"
-    AllowedPattern: '^(|arn:aws:sqs:[^:]+:[0-9]{12}:[^:]+)$'
-    ConstraintDescription: Must be either empty or a valid SQS ARN (arn:aws:sqs:region:account:queue-name)
+    AllowedPattern: '^(|N/A|arn:aws:sqs:[^:]+:[0-9]{12}:[^:]+)$'
+    ConstraintDescription: Must be either empty, N/A, or a valid SQS ARN (arn:aws:sqs:region:account:queue-name)
   OpenTelemetryCollectorImage:
     Description: The image URI for the OpenTelemetry Collector container image.
     Type: String

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -70,13 +70,13 @@ Parameters:
   OpenTelemetryCollectorExternalAccessPrincipal:
     Description: AWS Principal (ARN or account ID) allowed to assume the OpenTelemetry Collector external access role. If left empty, will use the current AWS account ID. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery)
     Type: String
-    Default: ""
+    Default: "N/A"
     AllowedPattern: '^(|[0-9]{12}|arn:aws:.*:.*)$'
     ConstraintDescription: Must be either empty, a 12-digit AWS account ID, or a valid AWS ARN
   OpenTelemetryCollectorExternalNotificationChannelArn:
     Description: SQS Queue ARN to receive S3 event notifications for telemetry data. If left empty, no notifications will be configured. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery).
     Type: String
-    Default: ""
+    Default: "N/A"
     AllowedPattern: '^(|arn:aws:sqs:[^:]+:[0-9]{12}:[^:]+)$'
     ConstraintDescription: Must be either empty or a valid SQS ARN (arn:aws:sqs:region:account:queue-name)
   OpenTelemetryCollectorImage:
@@ -84,7 +84,7 @@ Parameters:
     Type: String
     Default: "otel/opentelemetry-collector-contrib:latest"
 Conditions:
-  HasNotificationChannel: !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, ""]]
+  HasNotificationChannel: !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
 Resources:
   Agent:
     Type: AWS::CloudFormation::Stack

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -172,15 +172,6 @@ Resources:
                 aws:SecureTransport:
                   - false
     Type: AWS::S3::BucketPolicy
-  OpenTelemetryCollectorIngressRule:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !GetAtt OpenTelemetryCollector.Outputs.OpenTelemetryCollectorSecurityGroupId
-      IpProtocol: tcp
-      FromPort: 4317
-      ToPort: 4318
-      SourceSecurityGroupId: !GetAtt OpenTelemetryCollector.Outputs.OpenTelemetryCollectorSecurityGroupId
-      Description: Allow TCP ingress on ports 4317 and 4318 within the VPC
 Outputs:
   StorageBucketName:
     Description: Name of the S3 bucket used by the Agent and OpenTelemetry Collector to store data sampling records and telemetry data.

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -179,8 +179,8 @@ Resources:
       IpProtocol: tcp
       FromPort: 4317
       ToPort: 4318
-      CidrIp: 0.0.0.0/0
-      Description: Allow TCP ingress on ports 4317 and 4318 from all IPs within the VPC
+      SourceSecurityGroupId: !GetAtt OpenTelemetryCollector.Outputs.OpenTelemetryCollectorSecurityGroupId
+      Description: Allow TCP ingress on ports 4317 and 4318 within the VPC
 Outputs:
   StorageBucketName:
     Description: Name of the S3 bucket used by the Agent and OpenTelemetry Collector to store data sampling records and telemetry data.

--- a/templates/cloudformation/aws_apollo_agent.yaml
+++ b/templates/cloudformation/aws_apollo_agent.yaml
@@ -219,7 +219,7 @@ Resources:
           MCD_STORAGE_BUCKET_NAME: !If [ ShouldCreateStorage, !Ref Storage, !Select [5, !Split [':', !Ref ExistingStorageArn]] ]
           MCD_AGENT_IS_REMOTE_UPGRADABLE: !If [ ShouldCreateUpdatePolicy, True, False ]
           MCD_AGENT_WRAPPER_TYPE: CLOUDFORMATION
-          MCD_AGENT_WRAPPER_VERSION: 1.0.1
+          MCD_AGENT_WRAPPER_VERSION: 1.1.0
           MCD_STACK_ID: !Ref 'AWS::StackId'
           MCD_LOG_GROUP_ID: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${AWS::Partition}/lambda/${AWS::StackName}-AgentLambda"
           MCD_AGENT_CONNECTED_TO_A_VPC: !If [ ShouldConnectVPC, True, False ]

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -116,7 +116,7 @@ Resources:
           Value: "mcd-otel-collector"
         - Key: Provider
           Value: "monte-carlo"
-  LoadBalancer:
+  NetworkLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Scheme: internal
@@ -173,7 +173,7 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroupGRPC
-      LoadBalancerArn: !Ref LoadBalancer
+      LoadBalancerArn: !Ref NetworkLoadBalancer
       Port: !Ref GRPCPort
       Protocol: TCP
   ListenerHTTP:
@@ -182,7 +182,7 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroupHTTP
-      LoadBalancerArn: !Ref LoadBalancer
+      LoadBalancerArn: !Ref NetworkLoadBalancer
       Port: !Ref HTTPPort
       Protocol: TCP
   EcsCluster:
@@ -424,12 +424,12 @@ Resources:
 Outputs:
   OpenTelemetryCollectorGRPCEndpoint:
     Description: The gRPC endpoint for the OpenTelemetry Collector
-    Value: !Sub "${LoadBalancer.DNSName}:${GRPCPort}"
+    Value: !Sub "${NetworkLoadBalancer.DNSName}:${GRPCPort}"
     Export:
       Name: !Sub "${AWS::StackName}:OpenTelemetryCollectorGRPCEndpoint"
   OpenTelemetryCollectorHTTPEndpoint:
     Description: The HTTP endpoint for the OpenTelemetry Collector
-    Value: !Sub "http://${LoadBalancer.DNSName}:${HTTPPort}"
+    Value: !Sub "http://${NetworkLoadBalancer.DNSName}:${HTTPPort}"
     Export:
       Name: !Sub "${AWS::StackName}:OpenTelemetryCollectorHTTPEndpoint"
   OpenTelemetryCollectorExternalAccessRoleArn:

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -421,6 +421,15 @@ Resources:
           Value: "mcd-otel-collector"
         - Key: Provider
           Value: "monte-carlo"
+  SecurityGroupIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: 4317
+      ToPort: 4318
+      SourceSecurityGroupId: !Ref SecurityGroup
+      Description: Allow TCP ingress on ports 4317 and 4318 from other resources associated with the security group within the VPC
 Outputs:
   OpenTelemetryCollectorGRPCEndpoint:
     Description: The gRPC endpoint for the OpenTelemetry Collector

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -122,6 +122,8 @@ Resources:
       Scheme: internal
       Type: network
       Subnets: !Ref ExistingSubnetIds
+      SecurityGroups:
+        - !Ref SecurityGroup
       Tags:
         - Key: Service
           Value: "mcd-otel-collector"

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -97,14 +97,14 @@ Parameters:
   ExternalAccessPrincipal:
     Description: Principal (AWS ARN/account ID or Federated identifier) allowed to assume the external access role. If left empty, will use the current AWS account ID. Update this value later after the CF stack is created.
     Type: String
-    Default: ""
+    Default: "N/A"
   ExternalAccessPrincipalType:
     Description: Type of principal for external access role
     Type: String
     Default: "AWS"
     AllowedValues: ["AWS", "Federated"]
 Conditions:
-  UseCurrentAccount: !Equals [!Ref ExternalAccessPrincipal, ""]
+  UseCurrentAccount: !Equals [!Ref ExternalAccessPrincipal, "N/A"]
   UseAWSPrincipal: !Equals [!Ref ExternalAccessPrincipalType, "AWS"]
 Resources:
   LogGroup:


### PR DESCRIPTION
* Make sure there is a default ingress rule allowing traffic to ports 4317, 4318 to the open telemetry collector.
* Update agent wrapper version
* Fix inconsistencies in parameter default values