### PR TITLE
chore: add existing SecurityGroupId param

### DIFF
--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -29,6 +29,12 @@ Parameters:
   ExistingSubnetIds:
     Description: List of subnet IDs where the Agent and OpenTelemetry Collector will be deployed (should be private subnets)
     Type: List<AWS::EC2::Subnet::Id>
+  ExistingSecurityGroupId:
+    Description: Optional additional security group ID to attach to the OpenTelemetry Collector resources. If provided, this security group will be added to the Network Load Balancer and ECS Service.
+    Type: String
+    Default: "N/A"
+    AllowedPattern: '^(|sg-[0-9a-f]*)$'
+    ConstraintDescription: Must be either 'N/A' or a valid security group ID (sg-xxxxxxxxx)
   MonteCarloCloudAccountId:
     Description: >
       For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
@@ -106,6 +112,7 @@ Resources:
       Parameters:
         ExistingVpcId: !Ref ExistingVpcId
         ExistingSubnetIds: !Join [ ',', !Ref ExistingSubnetIds ]
+        ExistingSecurityGroupId: !Ref ExistingSecurityGroupId
         TelemetryDataBucketArn: !GetAtt Storage.Arn
         ExternalID: !Ref OpenTelemetryCollectorExternalID
         ExternalAccessPrincipal: !Ref OpenTelemetryCollectorExternalAccessPrincipal

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -33,8 +33,8 @@ Parameters:
     Description: Optional additional security group ID to attach to the OpenTelemetry Collector resources. If provided, this security group will be added to the Network Load Balancer and ECS Service.
     Type: String
     Default: "N/A"
-    AllowedPattern: '^(|sg-[0-9a-f]*)$'
-    ConstraintDescription: Must be either 'N/A' or a valid security group ID (sg-xxxxxxxxx)
+    AllowedPattern: '^(|N/A|sg-[0-9a-f]*)$'
+    ConstraintDescription: Must be either empty, N/A, or a valid security group ID (sg-xxxxxxxxx)
   MonteCarloCloudAccountId:
     Description: >
       For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 

--- a/templates/cloudformation/aws_generic_agent_ecs.yaml
+++ b/templates/cloudformation/aws_generic_agent_ecs.yaml
@@ -66,20 +66,6 @@ Resources:
         - Key: 'mcd:agent:platform'
           Value: 'aws_generic'
 
-  # VPC Endpoint for CloudWatch Logs (recommended for private subnets)
-  CloudWatchLogsVpcEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      VpcId: !Ref VpcId
-      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.logs'
-      VpcEndpointType: Interface
-      SubnetIds: !Ref VpcSubnetIds
-      SecurityGroupIds:
-        - !Ref SecurityGroupId
-      Tags:
-        - Key: 'mcd:agent:platform'
-          Value: 'aws_generic'
-
   EcsCluster:
     Type: 'AWS::ECS::Cluster'
     Properties:

--- a/templates/cloudformation/aws_generic_agent_ecs.yaml
+++ b/templates/cloudformation/aws_generic_agent_ecs.yaml
@@ -66,6 +66,20 @@ Resources:
         - Key: 'mcd:agent:platform'
           Value: 'aws_generic'
 
+  # VPC Endpoint for CloudWatch Logs (recommended for private subnets)
+  CloudWatchLogsVpcEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref VpcId
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.logs'
+      VpcEndpointType: Interface
+      SubnetIds: !Ref VpcSubnetIds
+      SecurityGroupIds:
+        - !Ref SecurityGroupId
+      Tags:
+        - Key: 'mcd:agent:platform'
+          Value: 'aws_generic'
+
   EcsCluster:
     Type: 'AWS::ECS::Cluster'
     Properties:

--- a/templates/cloudformation/aws_generic_agent_ecs.yaml
+++ b/templates/cloudformation/aws_generic_agent_ecs.yaml
@@ -264,16 +264,12 @@ Resources:
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Sid: 'CloudWatchLogsAccess'
+              - Sid: 'FilterLogGroupLogs'
                 Effect: 'Allow'
                 Action:
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                  - 'logs:DescribeLogGroups'
                   - 'logs:FilterLogEvents'
                 Resource:
                   - !GetAtt LogGroup.Arn
-                  - !Sub '${LogGroup.Arn}:*'
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
       Tags:

--- a/templates/cloudformation/aws_generic_agent_ecs.yaml
+++ b/templates/cloudformation/aws_generic_agent_ecs.yaml
@@ -264,12 +264,16 @@ Resources:
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Sid: 'FilterLogGroupLogs'
+              - Sid: 'CloudWatchLogsAccess'
                 Effect: 'Allow'
                 Action:
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                  - 'logs:DescribeLogGroups'
                   - 'logs:FilterLogEvents'
                 Resource:
                   - !GetAtt LogGroup.Arn
+                  - !Sub '${LogGroup.Arn}:*'
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
       Tags:

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -220,21 +220,6 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
-      Policies:
-        - PolicyName: CloudWatchLogsAccess
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: 'CloudWatchLogsAccess'
-                Effect: 'Allow'
-                Action:
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                  - 'logs:DescribeLogGroups'
-                  - 'logs:FilterLogEvents'
-                Resource:
-                  - !GetAtt LogGroup.Arn
-                  - !Sub '${LogGroup.Arn}:*'
       Tags:
         - Key: Service
           Value: "mcd-otel-collector"

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -210,6 +210,21 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: CloudWatchLogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: 'CloudWatchLogsAccess'
+                Effect: 'Allow'
+                Action:
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                  - 'logs:DescribeLogGroups'
+                  - 'logs:FilterLogEvents'
+                Resource:
+                  - !GetAtt LogGroup.Arn
+                  - !Sub '${LogGroup.Arn}:*'
       Tags:
         - Key: Service
           Value: "mcd-otel-collector"

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -37,8 +37,8 @@ Parameters:
     Description: Optional additional security group ID to attach to the OpenTelemetry Collector resources. If provided, this security group will be added to the Network Load Balancer and ECS Service.
     Type: String
     Default: "N/A"
-    AllowedPattern: '^(|sg-[0-9a-f]*)$'
-    ConstraintDescription: Must be either 'N/A' or a valid security group ID (sg-xxxxxxxxx)
+    AllowedPattern: '^(|N/A|sg-[0-9a-f]*)$'
+    ConstraintDescription: Must be either empty, N/A, or a valid security group ID (sg-xxxxxxxxx)
   TelemetryDataBucketArn:
     Description: ARN of the S3 bucket to store OpenTelemetry data such as traces, metrics, and logs.
     Type: String

--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -33,6 +33,12 @@ Parameters:
     Description: >
       Comma-delimited list of private subnet IDs (at least 2) for deploying the OpenTelemetry Collector.
     Type: CommaDelimitedList
+  ExistingSecurityGroupId:
+    Description: Optional additional security group ID to attach to the OpenTelemetry Collector resources. If provided, this security group will be added to the Network Load Balancer and ECS Service.
+    Type: String
+    Default: "N/A"
+    AllowedPattern: '^(|sg-[0-9a-f]*)$'
+    ConstraintDescription: Must be either 'N/A' or a valid security group ID (sg-xxxxxxxxx)
   TelemetryDataBucketArn:
     Description: ARN of the S3 bucket to store OpenTelemetry data such as traces, metrics, and logs.
     Type: String
@@ -106,6 +112,7 @@ Parameters:
 Conditions:
   UseCurrentAccount: !Equals [!Ref ExternalAccessPrincipal, "N/A"]
   UseAWSPrincipal: !Equals [!Ref ExternalAccessPrincipalType, "AWS"]
+  HasAdditionalSecurityGroup: !Not [!Equals [!Ref ExistingSecurityGroupId, "N/A"]]
 Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -122,8 +129,11 @@ Resources:
       Scheme: internal
       Type: network
       Subnets: !Ref ExistingSubnetIds
-      SecurityGroups:
-        - !Ref SecurityGroup
+      SecurityGroups: !If
+        - HasAdditionalSecurityGroup
+        - - !Ref SecurityGroup
+          - !Ref ExistingSecurityGroupId
+        - - !Ref SecurityGroup
       Tags:
         - Key: Service
           Value: "mcd-otel-collector"
@@ -417,8 +427,11 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !Ref SecurityGroup
+          SecurityGroups: !If
+            - HasAdditionalSecurityGroup
+            - - !Ref SecurityGroup
+              - !Ref ExistingSecurityGroupId
+            - - !Ref SecurityGroup
           Subnets: !Ref ExistingSubnetIds
       TaskDefinition: !Ref TaskDefinition
       Tags:


### PR DESCRIPTION
Add additional optional parameter for existing SecurityGroupId. This is useful when a VPC is used to ensure that the VPC's CW Endpoint is accessible by the OpenTelemetry ECS task