### PR TITLE
feat: databricks otel stack

### DIFF
--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector_databricks.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector_databricks.yaml
@@ -1,0 +1,171 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Monte Carlo Agent with OpenTelemetry Collector and SQS queue for Databricks integration.
+Metadata:
+  License: >
+    Copyright 2023 Monte Carlo Data, Inc.
+
+    The Software contained herein (the "Software") is the intellectual property of Monte Carlo Data, Inc. ("Licensor"),
+    and Licensor retains all intellectual property rights in the Software, including any and all derivatives, changes and
+    improvements thereto. Only customers who have entered into a commercial agreement with Licensor for use or
+    purchase of the Software ("Licensee") are licensed or otherwise authorized to use the Software, and any Licensee
+    agrees that it obtains no copyright or other intellectual property rights to the Software, except for the license
+    expressly granted below or in accordance with the terms of their commercial agreement with Licensor (the
+    "Agreement"). Subject to the terms and conditions of the Agreement, Licensor grants Licensee a non-exclusive,
+    non-transferable, non-sublicensable, revocable, limited right and license to use the Software, in each case solely
+    internally within Licensee's organization for non-commercial purposes and only in connection with the service
+    provided by Licensor pursuant to the Agreement, and in object code form only. Without Licensor's express prior
+    written consent, Licensee may not, directly or indirectly, (i) distribute the Software, any portion thereof, or any
+    modifications, enhancements, or derivative works of any of the foregoing (collectively, the "Derivatives") to any
+    third party, (ii) license, market, sell, offer for sale or otherwise attempt to commercialize any Software, Derivatives,
+    or portions thereof, (iii) use the Software, Derivatives, or any portion thereof for the benefit of any third party, (iv)
+    use the Software, Derivatives, or any portion thereof in any manner or with respect to any commercial activity
+    which competes, or is reasonably likely to compete, with any business that Licensor conducts, proposes to conduct
+    or demonstrably anticipates conducting, at any time; or (v) seek any patent or other intellectual property rights or
+    protections over or in connection with any Software of Derivatives.
+Parameters:
+  ExistingVpcId:
+    Description: The VPC ID where the Agent and OpenTelemetry Collector will be deployed
+    Type: AWS::EC2::VPC::Id
+  ExistingSubnetIds:
+    Description: List of subnet IDs where the Agent and OpenTelemetry Collector will be deployed (should be private subnets)
+    Type: List<AWS::EC2::Subnet::Id>
+  MonteCarloCloudAccountId:
+    Description: >
+      For deployments on the V2 Platform, use 590183797493. Accounts created after April 24th, 2024, 
+      will automatically be on the V2 platform or newer. If you are using an older version of the platform, 
+      please contact your Monte Carlo representative for the ID.
+    Type: String
+    Default: 590183797493
+    AllowedPattern: '^[0-9]{12}$'
+    ConstraintDescription: Must be a valid 12-digit AWS account ID
+  AgentConcurrentExecutions:
+    Default: 20
+    Description: The number of concurrent lambda executions for the agent.
+    MaxValue: 200
+    MinValue: 0
+    Type: Number
+  AgentImageUri:
+    Default: 590183797493.dkr.ecr.*.amazonaws.com/mcd-agent:latest
+    Description: >
+      URI of the Agent container image (ECR Repo). Note that the region automatically maps to where this stack 
+      is deployed in.
+    Type: String
+  AgentMemorySize:
+    Default: 512
+    Description: >
+      The amount of memory (MB) available to the agent at runtime; this value can be any multiple of 
+      1 MB greater than 256MB.
+    MinValue: 256
+    MaxValue: 10240
+    Type: Number
+  OpenTelemetryCollectorExternalID:
+    Description: External ID for OpenTelemetry Collector S3 access. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery)
+    Type: String
+    Default: "N/A"
+  OpenTelemetryCollectorExternalPrincipalType:
+    Description: Type of principal for OpenTelemetry Collector external access role. For Snowflake and Databricks, use "AWS". For BigQuery, use "Federated".
+    Type: String
+    Default: "AWS"
+    AllowedValues: ["AWS", "Federated"]
+  OpenTelemetryCollectorExternalAccessPrincipal:
+    Description: AWS Principal (ARN or account ID) allowed to assume the OpenTelemetry Collector external access role. If left empty, will use the current AWS account ID. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery)
+    Type: String
+    Default: "N/A"
+    AllowedPattern: '^(|N/A|[0-9]{12}|arn:aws:.*:.*)$'
+    ConstraintDescription: Must be either empty, N/A, a 12-digit AWS account ID, or a valid AWS ARN
+  OpenTelemetryCollectorImage:
+    Description: The image URI for the OpenTelemetry Collector container image.
+    Type: String
+    Default: "otel/opentelemetry-collector-contrib:latest"
+
+Resources:
+  SqsNotificationQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "mcd-otel-collector-databricks-notifications-${AWS::StackName}"
+      VisibilityTimeoutSeconds: 30
+      MessageRetentionPeriod: 1209600
+      ReceiveMessageWaitTimeSeconds: 20
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
+        - Key: Purpose
+          Value: "databricks-notifications"
+  SqsNotificationQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref SqsNotificationQueue
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt SqsNotificationQueue.Arn
+            Condition:
+              ArnLike:
+                aws:SourceArn: !GetAtt AgentWithOtelCollector.Outputs.StorageBucketArn
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt AgentWithOtelCollector.Outputs.OpenTelemetryCollectorExternalAccessRoleArn
+            Action:
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+            Resource: !GetAtt SqsNotificationQueue.Arn
+  AgentWithOtelCollector:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://mcd-public-resources.s3.amazonaws.com/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+      Parameters:
+        ExistingVpcId: !Ref ExistingVpcId
+        ExistingSubnetIds: !Join [ ',', !Ref ExistingSubnetIds ]
+        MonteCarloCloudAccountId: !Ref MonteCarloCloudAccountId
+        AgentConcurrentExecutions: !Ref AgentConcurrentExecutions
+        AgentImageUri: !Ref AgentImageUri
+        AgentMemorySize: !Ref AgentMemorySize
+        OpenTelemetryCollectorExternalID: !Ref OpenTelemetryCollectorExternalID
+        OpenTelemetryCollectorExternalPrincipalType: !Ref OpenTelemetryCollectorExternalPrincipalType
+        OpenTelemetryCollectorExternalAccessPrincipal: !Ref OpenTelemetryCollectorExternalAccessPrincipal
+        OpenTelemetryCollectorExternalNotificationChannelArn: !GetAtt SqsNotificationQueue.Arn
+        OpenTelemetryCollectorImage: !Ref OpenTelemetryCollectorImage
+Outputs:
+  StorageBucketName:
+    Description: Name of the S3 bucket used by the Agent and OpenTelemetry Collector to store data sampling records and telemetry data.
+    Value: !GetAtt AgentWithOtelCollector.Outputs.StorageBucketName
+  StorageBucketArn:
+    Description: ARN of the S3 bucket used by the Agent and OpenTelemetry Collector to store data sampling records and telemetry data.
+    Value: !GetAtt AgentWithOtelCollector.Outputs.StorageBucketArn
+  AgentFunctionArn:
+    Description: Agent Function ARN. To be used in registering.
+    Value: !GetAtt AgentWithOtelCollector.Outputs.AgentFunctionArn
+  AgentInvocationRoleArn:
+    Description: Assumable role ARN. To be used in registering.
+    Value: !GetAtt AgentWithOtelCollector.Outputs.AgentInvocationRoleArn
+  AgentInvocationRoleExternalId:
+    Description: Assumable role External ID. To be used in registering.
+    Value: !GetAtt AgentWithOtelCollector.Outputs.AgentInvocationRoleExternalId
+  OpenTelemetryCollectorGRPCEndpoint:
+    Description: The gRPC endpoint for the OpenTelemetry Collector
+    Value: !GetAtt AgentWithOtelCollector.Outputs.OpenTelemetryCollectorGRPCEndpoint
+  OpenTelemetryCollectorHTTPEndpoint:
+    Description: The HTTP endpoint for the OpenTelemetry Collector
+    Value: !GetAtt AgentWithOtelCollector.Outputs.OpenTelemetryCollectorHTTPEndpoint
+  OpenTelemetryCollectorExternalAccessRoleArn:
+    Description: The ARN of the IAM role for external access to the OpenTelemetry S3 bucket
+    Value: !GetAtt AgentWithOtelCollector.Outputs.OpenTelemetryCollectorExternalAccessRoleArn
+  OpenTelemetryCollectorSecurityGroupId:
+    Description: The ID of the security group for the OpenTelemetry Collector
+    Value: !GetAtt AgentWithOtelCollector.Outputs.OpenTelemetryCollectorSecurityGroupId
+  SqsNotificationQueueArn:
+    Description: The ARN of the SQS queue for S3 event notifications
+    Value: !GetAtt SqsNotificationQueue.Arn
+  SqsNotificationQueueUrl:
+    Description: The URL of the SQS queue for S3 event notifications
+    Value: !Ref SqsNotificationQueue 


### PR DESCRIPTION
Adds a new parent stack for deploying the OpenTelemetry Collector with the ability to write traces to Databricks using a SQS queue managed by the stack