### PR TITLE
chore: make iam role self-assuming

### DIFF
--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -288,8 +288,7 @@ Resources:
               - !If
                 - UseAWSPrincipal
                 - AWS:
-                - - !Ref ExternalAccessPrincipal
-                  # Ensure the role is self-assuming
+                  - !Ref ExternalAccessPrincipal
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-EAR"
                 - Federated: !Ref ExternalAccessPrincipal
             Action: sts:AssumeRole


### PR DESCRIPTION
the ExternalAccessRole needs to have a policy that allows the role to be self-assumed. Databricks [docs](https://community.databricks.com/t5/product-platform-updates/update-your-uc-aws-iam-roles-to-include-self-assume-capabilities/ba-p/67347).