### PR TITLE
chore: update otel config to include service name in file path

### DIFF
--- a/templates/cloudformation/aws_otel_collector_ecs.yaml
+++ b/templates/cloudformation/aws_otel_collector_ecs.yaml
@@ -362,20 +362,26 @@ Resources:
                       s3uploader:
                         region: ${AWS::Region}
                         s3_bucket: ${ExternalS3BucketName}
-                        s3_prefix: mcd/otel-collector/traces
+                        s3_base_prefix: 'mcd/otel-collector/traces'
                         file_prefix: traces
+                      resource_attrs_to_s3:
+                        s3_prefix: "service.name"
                     awss3/metrics:
                       s3uploader:
                         region: ${AWS::Region}
                         s3_bucket: ${ExternalS3BucketName}
-                        s3_prefix: mcd/otel-collector/metrics
+                        s3_base_prefix: 'mcd/otel-collector/metrics'
                         file_prefix: metrics
+                      resource_attrs_to_s3:
+                        s3_prefix: "service.name"
                     awss3/logs:
                       s3uploader:
                         region: ${AWS::Region}
                         s3_bucket: ${ExternalS3BucketName}
-                        s3_prefix: mcd/otel-collector/logs
+                        s3_base_prefix: 'mcd/otel-collector/logs'
                         file_prefix: logs
+                      resource_attrs_to_s3:
+                        s3_prefix: "service.name"
 
                   service:
                     pipelines:


### PR DESCRIPTION
use new `s3_base_prefix` feature of the aws s3uploader in OpenTelemetry Collector v0.136.0 in combination with the `resource_attrs_to_s3` feature to include the `service.name` attribute from the trace data in the S3 file path.

For example, given traces from agents with `service.name` values `foo`, `bar`, `blah`, the traces would be written to the following directories:

- `s3://my-bucket/mcd/otel-collector/traces/foo/year=2025/month=08/day=29/…`
- `s3://my-bucket/mcd/otel-collector/traces/bar/year=2025/month=08/day=29/…`
- `s3://my-bucket/mcd/otel-collector/traces/blah/year=2025/month=08/day=29/…`