### PR TITLE
feat: support SNS or SQS notification channels

### DIFF
--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -103,6 +103,9 @@ Conditions:
   IsSQSNotification: !And
     - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
     - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sqs"]
+  IsSNSNotification: !And
+    - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
+    - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sns"]
 Resources:
   Agent:
     Type: AWS::CloudFormation::Stack
@@ -192,6 +195,21 @@ Resources:
                         Value: mcd/otel-collector/
         - !Ref AWS::NoValue
     Type: AWS::S3::Bucket
+  SNSTopicPolicy:
+    Condition: IsSNSNotification
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action: SNS:Publish
+            Resource: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
+            Condition:
+              ArnLike:
+                aws:SourceArn: !GetAtt Storage.Arn
+    Type: AWS::SNS::TopicPolicy
   StorageSSLPolicy:
     Properties:
       Bucket: !Ref Storage

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -100,11 +100,15 @@ Parameters:
 Conditions:
   UseExistingTelemetryDataBucket: !Not [!Equals [!Ref OpenTelemetryCollectorExistingBucketArn, "N/A"]]
   HasNotificationChannel: !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
-  IsSQSNotification: !And
+  IsValidARN: !And
     - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
+    - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, ""]]
+    - !Equals [!Select [0, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "arn"]
+  IsSQSNotification: !And
+    - !Condition IsValidARN
     - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sqs"]
   IsSNSNotification: !And
-    - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
+    - !Condition IsValidARN
     - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sns"]
 Resources:
   Agent:

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -1,5 +1,4 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::LanguageExtensions
 Description: Sample template that deploys a Monte Carlo Agent, Data Store, and OpenTelemetry Collector.
 Metadata:
   License: >
@@ -105,10 +104,10 @@ Conditions:
     - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, ""]]
   IsSQSNotification: !And
     - !Condition HasNotificationChannel
-    - !Not [!Equals [!Length [!Split ["arn:aws:sqs", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], 1]]
+    - !Not [!Equals [!Select [0, !Split ["arn:aws:sqs", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], !Ref OpenTelemetryCollectorExternalNotificationChannelArn]]
   IsSNSNotification: !And
     - !Condition HasNotificationChannel
-    - !Not [!Equals [!Length [!Split ["arn:aws:sns", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], 1]]
+    - !Not [!Equals [!Select [0, !Split ["arn:aws:sns", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], !Ref OpenTelemetryCollectorExternalNotificationChannelArn]]
 Resources:
   Agent:
     Type: AWS::CloudFormation::Stack

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -80,11 +80,11 @@ Parameters:
     AllowedPattern: '^(|N/A|[0-9]{12}|arn:aws:.*:.*)$'
     ConstraintDescription: Must be either empty, N/A, a 12-digit AWS account ID, or a valid AWS ARN
   OpenTelemetryCollectorExternalNotificationChannelArn:
-    Description: SQS Queue ARN to receive S3 event notifications for telemetry data. If left empty, no notifications will be configured. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery).
+    Description: SQS Queue ARN or SNS Topic ARN to receive S3 event notifications for telemetry data. If left empty, no notifications will be configured. Update this value later after the CF stack is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery).
     Type: String
     Default: "N/A"
-    AllowedPattern: '^(|N/A|arn:aws:sqs:[^:]+:[0-9]{12}:[^:]+)$'
-    ConstraintDescription: Must be either empty, N/A, or a valid SQS ARN (arn:aws:sqs:region:account:queue-name)
+    AllowedPattern: '^(|N/A|arn:aws:(sqs|sns):[^:]+:[0-9]{12}:[^:]+)$'
+    ConstraintDescription: Must be either empty, N/A, a valid SQS ARN (arn:aws:sqs:region:account:queue-name), or a valid SNS ARN (arn:aws:sns:region:account:topic-name)
   OpenTelemetryCollectorImage:
     Description: The image URI for the OpenTelemetry Collector container image.
     Type: String
@@ -100,6 +100,12 @@ Parameters:
 Conditions:
   UseExistingTelemetryDataBucket: !Not [!Equals [!Ref OpenTelemetryCollectorExistingBucketArn, "N/A"]]
   HasNotificationChannel: !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
+  IsSQSNotification: !And
+    - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
+    - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sqs"]
+  IsSNSNotification: !And
+    - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
+    - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sns"]
 Resources:
   Agent:
     Type: AWS::CloudFormation::Stack
@@ -155,21 +161,38 @@ Resources:
             Status: Enabled
       NotificationConfiguration: !If
         - HasNotificationChannel
-        - QueueConfigurations:
-            - Event: s3:ObjectCreated:*
-              Queue: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
-              Filter:
-                S3Key:
-                  Rules:
-                    - Name: prefix
-                      Value: mcd/otel-collector/
-            - Event: s3:ObjectRemoved:*
-              Queue: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
-              Filter:
-                S3Key:
-                  Rules:
-                    - Name: prefix
-                      Value: mcd/otel-collector/
+        - !If
+          - IsSQSNotification
+          - QueueConfigurations:
+              - Event: s3:ObjectCreated:*
+                Queue: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
+                Filter:
+                  S3Key:
+                    Rules:
+                      - Name: prefix
+                        Value: mcd/otel-collector/
+              - Event: s3:ObjectRemoved:*
+                Queue: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
+                Filter:
+                  S3Key:
+                    Rules:
+                      - Name: prefix
+                        Value: mcd/otel-collector/
+          - TopicConfigurations:
+              - Event: s3:ObjectCreated:*
+                Topic: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
+                Filter:
+                  S3Key:
+                    Rules:
+                      - Name: prefix
+                        Value: mcd/otel-collector/
+              - Event: s3:ObjectRemoved:*
+                Topic: !Ref OpenTelemetryCollectorExternalNotificationChannelArn
+                Filter:
+                  S3Key:
+                    Rules:
+                      - Name: prefix
+                        Value: mcd/otel-collector/
         - !Ref AWS::NoValue
     Type: AWS::S3::Bucket
   StorageSSLPolicy:

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::LanguageExtensions
 Description: Sample template that deploys a Monte Carlo Agent, Data Store, and OpenTelemetry Collector.
 Metadata:
   License: >
@@ -99,17 +100,15 @@ Parameters:
     Default: "N/A"
 Conditions:
   UseExistingTelemetryDataBucket: !Not [!Equals [!Ref OpenTelemetryCollectorExistingBucketArn, "N/A"]]
-  HasNotificationChannel: !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
-  IsValidARN: !And
+  HasNotificationChannel: !And
     - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
     - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, ""]]
-    - !Equals [!Select [0, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "arn"]
   IsSQSNotification: !And
-    - !Condition IsValidARN
-    - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sqs"]
+    - !Condition HasNotificationChannel
+    - !Not [!Equals [!Length [!Split ["arn:aws:sqs", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], 1]]
   IsSNSNotification: !And
-    - !Condition IsValidARN
-    - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sns"]
+    - !Condition HasNotificationChannel
+    - !Not [!Equals [!Length [!Split ["arn:aws:sns", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], 1]]
 Resources:
   Agent:
     Type: AWS::CloudFormation::Stack

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -198,6 +198,8 @@ Resources:
   SNSTopicPolicy:
     Condition: IsSNSNotification
     Properties:
+      Topics:
+        - !Ref OpenTelemetryCollectorExternalNotificationChannelArn
       PolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
+++ b/templates/cloudformation/aws_agent_with_opentelemetry_collector.yaml
@@ -103,9 +103,6 @@ Conditions:
   IsSQSNotification: !And
     - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
     - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sqs"]
-  IsSNSNotification: !And
-    - !Not [!Equals [!Ref OpenTelemetryCollectorExternalNotificationChannelArn, "N/A"]]
-    - !Equals [!Select [2, !Split [":", !Ref OpenTelemetryCollectorExternalNotificationChannelArn]], "sns"]
 Resources:
   Agent:
     Type: AWS::CloudFormation::Stack

--- a/templates/terraform/aws_agent_with_opentelemetry_collector/main.tf
+++ b/templates/terraform/aws_agent_with_opentelemetry_collector/main.tf
@@ -21,6 +21,10 @@ locals {
   use_existing_telemetry_data_bucket = var.opentelemetry_collector_existing_bucket_arn != "N/A"
   has_notification_channel           = var.opentelemetry_collector_external_notification_channel_arn != "N/A"
 
+  # Detect notification channel type
+  is_sqs_notification = local.has_notification_channel && can(regex("^arn:aws:sqs:", var.opentelemetry_collector_external_notification_channel_arn))
+  is_sns_notification = local.has_notification_channel && can(regex("^arn:aws:sns:", var.opentelemetry_collector_external_notification_channel_arn))
+
   # Common tags
   common_tags = {
     Service  = var.deployment_name
@@ -76,14 +80,28 @@ resource "aws_s3_bucket_lifecycle_configuration" "otel_collector_lifecycle" {
   }
 }
 
-# S3 Bucket Notification Configuration for OpenTelemetry Collector (conditional)
-resource "aws_s3_bucket_notification" "storage_notification" {
-  count  = (local.has_notification_channel && !local.use_existing_telemetry_data_bucket) ? 1 : 0
+# S3 Bucket Notification Configuration for OpenTelemetry Collector - SQS (conditional)
+resource "aws_s3_bucket_notification" "storage_notification_sqs" {
+  count  = (local.is_sqs_notification && !local.use_existing_telemetry_data_bucket) ? 1 : 0
   bucket = module.agent.mcd_agent_storage_bucket_name
 
   queue {
     id        = "${var.deployment_name}-opentelemetry-collector-notifications"
     queue_arn = var.opentelemetry_collector_external_notification_channel_arn
+    events    = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+
+    filter_prefix = "mcd/otel-collector/"
+  }
+}
+
+# S3 Bucket Notification Configuration for OpenTelemetry Collector - SNS (conditional)
+resource "aws_s3_bucket_notification" "storage_notification_sns" {
+  count  = (local.is_sns_notification && !local.use_existing_telemetry_data_bucket) ? 1 : 0
+  bucket = module.agent.mcd_agent_storage_bucket_name
+
+  topic {
+    id        = "${var.deployment_name}-opentelemetry-collector-notifications"
+    topic_arn = var.opentelemetry_collector_external_notification_channel_arn
     events    = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
 
     filter_prefix = "mcd/otel-collector/"

--- a/templates/terraform/aws_agent_with_opentelemetry_collector/variables.tf
+++ b/templates/terraform/aws_agent_with_opentelemetry_collector/variables.tf
@@ -93,12 +93,12 @@ variable "opentelemetry_collector_external_access_principal" {
 }
 
 variable "opentelemetry_collector_external_notification_channel_arn" {
-  description = "SQS Queue ARN to receive S3 event notifications for telemetry data. If left empty, no notifications will be configured. Update this value later after the Terraform deployment is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery)."
+  description = "SQS Queue ARN or SNS Topic ARN to receive S3 event notifications for telemetry data. If left empty, no notifications will be configured. Update this value later after the Terraform deployment is created to the value provided by your warehouse (e.g. Snowflake, Databricks, BigQuery)."
   type        = string
   default     = "N/A"
   validation {
-    condition     = can(regex("^(|N/A|arn:aws:sqs:[^:]+:[0-9]{12}:[^:]+)$", var.opentelemetry_collector_external_notification_channel_arn))
-    error_message = "Must be either empty, N/A, or a valid SQS ARN (arn:aws:sqs:region:account:queue-name)"
+    condition     = can(regex("^(|N/A|arn:aws:(sqs|sns):[^:]+:[0-9]{12}:[^:]+)$", var.opentelemetry_collector_external_notification_channel_arn))
+    error_message = "Must be either empty, N/A, a valid SQS ARN (arn:aws:sqs:region:account:queue-name), or a valid SNS ARN (arn:aws:sns:region:account:topic-name)"
   }
 }
 


### PR DESCRIPTION
support users providing either a SQS queue or SNS topic ARN to the `OpenTelemetryCollectorExternalNotificationChannelArn` CF or `opentelemetry_collector_external_notification_channel_arn` terraform parameters

- validated terraform & CF deployment