### PR TITLE
feat: athena otel cloud formation template

### DIFF
--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -37,12 +37,6 @@ Parameters:
     AllowedPattern: '^arn:aws:s3:::.*$'
     ConstraintDescription: Must be a valid S3 bucket ARN
 
-  TelemetryDataBucketName:
-    Type: String
-    Description: Name of the S3 bucket containing telemetry data (extracted from the ARN)
-    AllowedPattern: '^[a-z0-9][a-z0-9-]*[a-z0-9]$'
-    ConstraintDescription: Must be a valid S3 bucket name
-
   SNSTopicArn:
     Type: String
     Description: ARN of an existing SNS topic to use for notifications. If left empty, a new SNS topic will be created.
@@ -71,13 +65,13 @@ Parameters:
 
 Conditions:
   UseExistingSNS: !Not [!Equals [!Ref SNSTopicArn, ""]]
+  CreateSNS: !Equals [!Ref SNSTopicArn, ""]
 
 Resources:
   # Glue Classifier
   GrokClassifier:
     Type: AWS::Glue::Classifier
     Properties:
-      Name: !Sub "${DeploymentName}-grok-classifier"
       GrokClassifier:
         Classification: grok
         GrokPattern: "%%{GREEDYDATA:value}"
@@ -85,14 +79,14 @@ Resources:
   # SNS Topic (only if not provided)
   TelemetryNotificationsTopic:
     Type: AWS::SNS::Topic
-    Condition: !Not [!Condition UseExistingSNS]
+    Condition: CreateSNS
     Properties:
       TopicName: !Sub "${DeploymentName}-telemetry-notifications"
 
   # SNS Topic Policy to allow S3 to publish (only if SNS topic was created)
   TelemetryNotificationsTopicPolicy:
     Type: AWS::SNS::TopicPolicy
-    Condition: !Not [!Condition UseExistingSNS]
+    Condition: CreateSNS
     Properties:
       Topics:
         - !Ref TelemetryNotificationsTopic
@@ -159,27 +153,6 @@ Resources:
       Protocol: sqs
       Endpoint: !GetAtt CrawlerQueue.Arn
 
-  # S3 Bucket Notification Configuration for OpenTelemetry Collector - SNS (only if SNS topic was created)
-  StorageNotificationSNS:
-    Type: AWS::S3::BucketNotification
-    Condition: !Not [!Condition UseExistingSNS]
-    DependsOn:
-      - TelemetryNotificationsTopic
-      - TelemetryNotificationsTopicPolicy
-    Properties:
-      Bucket: !Ref TelemetryDataBucketName
-      TopicConfigurations:
-        - Id: !Sub "${DeploymentName}-glue-crawler-sns-notification"
-          TopicArn: !Ref TelemetryNotificationsTopic
-          Event: 
-            - s3:ObjectCreated:*
-            - s3:ObjectRemoved:*
-          Filter:
-            S3Key:
-              Rules:
-                - Name: prefix
-                  Value: mcd/otel-collector/
-
   # IAM Role for Glue Crawler
   GlueCrawlerRole:
     Type: AWS::IAM::Role
@@ -243,7 +216,9 @@ Resources:
         - !Ref GrokClassifier
       Targets:
         S3Targets:
-          - Path: !Sub "s3://${TelemetryDataBucketName}/mcd/otel-collector/traces/"
+          - Path: !Sub 
+              - "s3://${BucketName}/mcd/otel-collector/traces/"
+              - BucketName: !Select [5, !Split [":", !Ref TelemetryDataBucketArn]]
             EventQueueArn: !GetAtt CrawlerQueue.Arn
       SchemaChangePolicy:
         DeleteBehavior: LOG
@@ -252,7 +227,7 @@ Resources:
         RecrawlBehavior: CRAWL_EVENT_MODE
       Schedule:
         ScheduleExpression: "cron(*/30 * * * ? *)"
-      Configuration: !Sub |
+      Configuration: |
         {
           "Version": 1.0,
           "CrawlerOutput": {

--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -249,10 +249,8 @@ Resources:
           }
         }
       Tags:
-        - Key: Service
-          Value: "mcd-otel-collector"
-        - Key: Provider
-          Value: "monte-carlo"
+        Service: "mcd-otel-collector"
+        Provider: "monte-carlo"
 
   # IAM Role for Lambda UDF
   LambdaUDFRole:

--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -75,6 +75,11 @@ Resources:
     Condition: CreateSNS
     Properties:
       TopicName: !Sub "${AWS::StackName}-telemetry-notifications"
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
 
   # SNS Topic Policy to allow S3 to publish (only if SNS topic was created)
   TelemetryNotificationsTopicPolicy:
@@ -102,6 +107,11 @@ Resources:
       QueueName: !Sub "${AWS::StackName}-glue-crawler-queue"
       MessageRetentionPeriod: 1209600  # 14 days
       ReceiveMessageWaitTimeSeconds: 20  # Long polling
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
 
   # SQS Queue Policy for SNS subscription
   CrawlerQueuePolicy:
@@ -188,6 +198,11 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:PurgeQueue
                 Resource: !GetAtt CrawlerQueue.Arn
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
 
   # Glue Database
   TelemetryDatabase:
@@ -233,6 +248,11 @@ Resources:
             "TableGroupingPolicy": "CombineCompatibleSchemas"
           }
         }
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
 
   # IAM Role for Lambda UDF
   LambdaUDFRole:
@@ -262,6 +282,11 @@ Resources:
                 Resource:
                   - "arn:aws:bedrock:*::foundation-model/anthropic.claude-*"
                   - "arn:aws:bedrock:*:*:inference-profile/*anthropic.claude-*"
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
 
   # Lambda Function for Athena UDF
   AthenaUDF:
@@ -277,6 +302,11 @@ Resources:
       ImageConfig:
         Command:
           - handler.lambda_handler
+      Tags:
+        - Key: Service
+          Value: "mcd-otel-collector"
+        - Key: Provider
+          Value: "monte-carlo"
 
 Outputs:
   GlueDatabaseName:

--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       GrokClassifier:
         Classification: grok
-        GrokPattern: "%%{GREEDYDATA:value}"
+        GrokPattern: "%{GREEDYDATA:value}"
 
   # SNS Topic (only if not provided)
   TelemetryNotificationsTopic:
@@ -267,7 +267,7 @@ Resources:
   AthenaUDF:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: mcd-agent-observability-bedrock-udf
+      FunctionName: mcd-agent-observability-bedrock-udf-2
       Role: !GetAtt LambdaUDFRole.Arn
       PackageType: Image
       Code:

--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -24,13 +24,6 @@ Metadata:
     protections over or in connection with any Software of Derivatives.
 
 Parameters:
-  DeploymentName:
-    Type: String
-    Description: Name of the deployment (used as prefix for naming resources)
-    Default: mcd-agent-with-otel
-    AllowedPattern: '^[a-zA-Z0-9-]+$'
-    ConstraintDescription: Deployment name must contain only alphanumeric characters and hyphens.
-
   TelemetryDataBucketArn:
     Type: String
     Description: ARN of the S3 bucket containing telemetry data
@@ -47,7 +40,7 @@ Parameters:
   LambdaUDFImageUri:
     Type: String
     Description: URI of the Lambda UDF container image
-    Default: ""
+    Default: "752656882040.dkr.ecr.us-east-1.amazonaws.com/mcd-otel-aws-athena-lambda-udf:latest"
 
   LambdaUDFTimeout:
     Type: Number
@@ -81,7 +74,7 @@ Resources:
     Type: AWS::SNS::Topic
     Condition: CreateSNS
     Properties:
-      TopicName: !Sub "${DeploymentName}-telemetry-notifications"
+      TopicName: !Sub "${AWS::StackName}-telemetry-notifications"
 
   # SNS Topic Policy to allow S3 to publish (only if SNS topic was created)
   TelemetryNotificationsTopicPolicy:
@@ -106,7 +99,7 @@ Resources:
   CrawlerQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub "${DeploymentName}-glue-crawler-queue"
+      QueueName: !Sub "${AWS::StackName}-glue-crawler-queue"
       MessageRetentionPeriod: 1209600  # 14 days
       ReceiveMessageWaitTimeSeconds: 20  # Long polling
 
@@ -157,7 +150,7 @@ Resources:
   GlueCrawlerRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${DeploymentName}-glue-crawler-role"
+      RoleName: !Sub "${AWS::StackName}-glue-crawler-role"
       Path: "/"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -169,7 +162,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
       Policies:
-        - PolicyName: !Sub "${DeploymentName}-glue-crawler-s3-policy"
+        - PolicyName: !Sub "${AWS::StackName}-glue-crawler-s3-policy"
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
@@ -181,7 +174,7 @@ Resources:
                 Resource:
                   - !Ref TelemetryDataBucketArn
                   - !Sub "${TelemetryDataBucketArn}/*"
-        - PolicyName: !Sub "${DeploymentName}-glue-crawler-sqs-policy"
+        - PolicyName: !Sub "${AWS::StackName}-glue-crawler-sqs-policy"
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
@@ -202,14 +195,14 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: !Sub "${DeploymentName}-telemetry-db"
+        Name: !Sub "${AWS::StackName}-telemetry-db"
         Description: "Database for OpenTelemetry telemetry data"
 
   # Glue Crawler
   TelemetryCrawler:
     Type: AWS::Glue::Crawler
     Properties:
-      Name: !Sub "${DeploymentName}-telemetry-crawler"
+      Name: !Sub "${AWS::StackName}-telemetry-crawler"
       Role: !GetAtt GlueCrawlerRole.Arn
       DatabaseName: !Ref TelemetryDatabase
       Classifiers:
@@ -245,7 +238,7 @@ Resources:
   LambdaUDFRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${DeploymentName}-lambda-udf-role"
+      RoleName: !Sub "${AWS::StackName}-lambda-udf-role"
       Path: "/"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -257,7 +250,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: !Sub "${DeploymentName}-lambda-udf-bedrock-policy"
+        - PolicyName: !Sub "${AWS::StackName}-lambda-udf-bedrock-policy"
           PolicyDocument:
             Version: '2012-10-17'
             Statement:

--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -292,7 +292,7 @@ Resources:
   AthenaUDF:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: mcd-agent-observability-bedrock-udf-2
+      FunctionName: mcd-agent-observability-bedrock-udf
       Role: !GetAtt LambdaUDFRole.Arn
       PackageType: Image
       Code:

--- a/templates/cloudformation/aws_otel_collector_athena.yaml
+++ b/templates/cloudformation/aws_otel_collector_athena.yaml
@@ -1,0 +1,351 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template that deploys Athena-specific resources for OpenTelemetry Collector, including Glue Database, Crawler, SNS/SQS notifications, and Lambda UDF
+Metadata:
+  License: >
+    Copyright 2025 Monte Carlo Data, Inc.
+
+    The Software contained herein (the "Software") is the intellectual property of Monte Carlo Data, Inc. ("Licensor"),
+    and Licensor retains all intellectual property rights in the Software, including any and all derivatives, changes and
+    improvements thereto. Only customers who have entered into a commercial agreement with Licensor for use or
+    purchase of the Software ("Licensee") are licensed or otherwise authorized to use the Software, and any Licensee
+    agrees that it obtains no copyright or other intellectual property rights to the Software, except for the license
+    expressly granted below or in accordance with the terms of their commercial agreement with Licensor (the
+    "Agreement"). Subject to the terms and conditions of the Agreement, Licensor grants Licensee a non-exclusive,
+    non-transferable, non-sublicensable, revocable, limited right and license to use the Software, in each case solely
+    internally within Licensee's organization for non-commercial purposes and only in connection with the service
+    provided by Licensor pursuant to the Agreement, and in object code form only. Without Licensor's express prior
+    written consent, Licensee may not, directly or indirectly, (i) distribute the Software, any portion thereof, or any
+    modifications, enhancements, or derivative works of any of the foregoing (collectively, the "Derivatives") to any
+    third party, (ii) license, market, sell, offer for sale or otherwise attempt to commercialize any Software, Derivatives,
+    or portions thereof, (iii) use the Software, Derivatives, or any portion thereof for the benefit of any third party, (iv)
+    use the Software, Derivatives, or any portion thereof in any manner or with respect to any commercial activity
+    which competes, or is reasonably likely to compete, with any business that Licensor conducts, proposes to conduct
+    or demonstrably anticipates conducting, at any time; or (v) seek any patent or other intellectual property rights or
+    protections over or in connection with any Software of Derivatives.
+
+Parameters:
+  DeploymentName:
+    Type: String
+    Description: Name of the deployment (used as prefix for naming resources)
+    Default: mcd-agent-with-otel
+    AllowedPattern: '^[a-zA-Z0-9-]+$'
+    ConstraintDescription: Deployment name must contain only alphanumeric characters and hyphens.
+
+  TelemetryDataBucketArn:
+    Type: String
+    Description: ARN of the S3 bucket containing telemetry data
+    AllowedPattern: '^arn:aws:s3:::.*$'
+    ConstraintDescription: Must be a valid S3 bucket ARN
+
+  TelemetryDataBucketName:
+    Type: String
+    Description: Name of the S3 bucket containing telemetry data (extracted from the ARN)
+    AllowedPattern: '^[a-z0-9][a-z0-9-]*[a-z0-9]$'
+    ConstraintDescription: Must be a valid S3 bucket name
+
+  SNSTopicArn:
+    Type: String
+    Description: ARN of an existing SNS topic to use for notifications. If left empty, a new SNS topic will be created.
+    Default: ""
+    AllowedPattern: '^(|arn:aws:sns:[^:]+:[0-9]{12}:[^:]+)$'
+    ConstraintDescription: Must be either empty or a valid SNS topic ARN
+
+  LambdaUDFImageUri:
+    Type: String
+    Description: URI of the Lambda UDF container image
+    Default: ""
+
+  LambdaUDFTimeout:
+    Type: Number
+    Description: Timeout in seconds for the Lambda UDF function
+    Default: 300
+    MinValue: 1
+    MaxValue: 900
+
+  LambdaUDFMemorySize:
+    Type: Number
+    Description: Memory size in MB for the Lambda UDF function
+    Default: 512
+    MinValue: 128
+    MaxValue: 10240
+
+Conditions:
+  UseExistingSNS: !Not [!Equals [!Ref SNSTopicArn, ""]]
+
+Resources:
+  # Glue Classifier
+  GrokClassifier:
+    Type: AWS::Glue::Classifier
+    Properties:
+      Name: !Sub "${DeploymentName}-grok-classifier"
+      GrokClassifier:
+        Classification: grok
+        GrokPattern: "%%{GREEDYDATA:value}"
+
+  # SNS Topic (only if not provided)
+  TelemetryNotificationsTopic:
+    Type: AWS::SNS::Topic
+    Condition: !Not [!Condition UseExistingSNS]
+    Properties:
+      TopicName: !Sub "${DeploymentName}-telemetry-notifications"
+
+  # SNS Topic Policy to allow S3 to publish (only if SNS topic was created)
+  TelemetryNotificationsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Condition: !Not [!Condition UseExistingSNS]
+    Properties:
+      Topics:
+        - !Ref TelemetryNotificationsTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action: SNS:Publish
+            Resource: !Ref TelemetryNotificationsTopic
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Ref TelemetryDataBucketArn
+
+  # SQS Queue
+  CrawlerQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${DeploymentName}-glue-crawler-queue"
+      MessageRetentionPeriod: 1209600  # 14 days
+      ReceiveMessageWaitTimeSeconds: 20  # Long polling
+
+  # SQS Queue Policy for SNS subscription
+  CrawlerQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref CrawlerQueue
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: sqs:SendMessage
+            Resource: !GetAtt CrawlerQueue.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !If
+                  - UseExistingSNS
+                  - !Ref SNSTopicArn
+                  - !Ref TelemetryNotificationsTopic
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt GlueCrawlerRole.Arn
+            Action:
+              - sqs:DeleteMessage
+              - sqs:GetQueueUrl
+              - sqs:ReceiveMessage
+              - sqs:GetQueueAttributes
+              - sqs:SetQueueAttributes
+              - sqs:PurgeQueue
+            Resource: !GetAtt CrawlerQueue.Arn
+
+  # SNS Topic Subscription
+  SQSTopicSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !If
+        - UseExistingSNS
+        - !Ref SNSTopicArn
+        - !Ref TelemetryNotificationsTopic
+      Protocol: sqs
+      Endpoint: !GetAtt CrawlerQueue.Arn
+
+  # S3 Bucket Notification Configuration for OpenTelemetry Collector - SNS (only if SNS topic was created)
+  StorageNotificationSNS:
+    Type: AWS::S3::BucketNotification
+    Condition: !Not [!Condition UseExistingSNS]
+    DependsOn:
+      - TelemetryNotificationsTopic
+      - TelemetryNotificationsTopicPolicy
+    Properties:
+      Bucket: !Ref TelemetryDataBucketName
+      TopicConfigurations:
+        - Id: !Sub "${DeploymentName}-glue-crawler-sns-notification"
+          TopicArn: !Ref TelemetryNotificationsTopic
+          Event: 
+            - s3:ObjectCreated:*
+            - s3:ObjectRemoved:*
+          Filter:
+            S3Key:
+              Rules:
+                - Name: prefix
+                  Value: mcd/otel-collector/
+
+  # IAM Role for Glue Crawler
+  GlueCrawlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${DeploymentName}-glue-crawler-role"
+      Path: "/"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: glue.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+      Policies:
+        - PolicyName: !Sub "${DeploymentName}-glue-crawler-s3-policy"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource:
+                  - !Ref TelemetryDataBucketArn
+                  - !Sub "${TelemetryDataBucketArn}/*"
+        - PolicyName: !Sub "${DeploymentName}-glue-crawler-sqs-policy"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: VisualEditor0
+                Effect: Allow
+                Action:
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueUrl
+                  - sqs:ReceiveMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:SetQueueAttributes
+                  - sqs:PurgeQueue
+                Resource: !GetAtt CrawlerQueue.Arn
+
+  # Glue Database
+  TelemetryDatabase:
+    Type: AWS::Glue::Database
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseInput:
+        Name: !Sub "${DeploymentName}-telemetry-db"
+        Description: "Database for OpenTelemetry telemetry data"
+
+  # Glue Crawler
+  TelemetryCrawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Name: !Sub "${DeploymentName}-telemetry-crawler"
+      Role: !GetAtt GlueCrawlerRole.Arn
+      DatabaseName: !Ref TelemetryDatabase
+      Classifiers:
+        - !Ref GrokClassifier
+      Targets:
+        S3Targets:
+          - Path: !Sub "s3://${TelemetryDataBucketName}/mcd/otel-collector/traces/"
+            EventQueueArn: !GetAtt CrawlerQueue.Arn
+      SchemaChangePolicy:
+        DeleteBehavior: LOG
+        UpdateBehavior: UPDATE_IN_DATABASE
+      RecrawlPolicy:
+        RecrawlBehavior: CRAWL_EVENT_MODE
+      Schedule:
+        ScheduleExpression: "cron(*/30 * * * ? *)"
+      Configuration: !Sub |
+        {
+          "Version": 1.0,
+          "CrawlerOutput": {
+            "Tables": {
+              "AddOrUpdateBehavior": "MergeNewColumns",
+              "TableThreshold": 1
+            }
+          },
+          "Grouping": {
+            "TableGroupingPolicy": "CombineCompatibleSchemas"
+          }
+        }
+
+  # IAM Role for Lambda UDF
+  LambdaUDFRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${DeploymentName}-lambda-udf-role"
+      Path: "/"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: !Sub "${DeploymentName}-lambda-udf-bedrock-policy"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AllowInvokeBedrock
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                  - bedrock:InvokeModelWithResponseStream
+                Resource:
+                  - "arn:aws:bedrock:*::foundation-model/anthropic.claude-*"
+                  - "arn:aws:bedrock:*:*:inference-profile/*anthropic.claude-*"
+
+  # Lambda Function for Athena UDF
+  AthenaUDF:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: mcd-agent-observability-bedrock-udf
+      Role: !GetAtt LambdaUDFRole.Arn
+      PackageType: Image
+      Code:
+        ImageUri: !Ref LambdaUDFImageUri
+      Timeout: !Ref LambdaUDFTimeout
+      MemorySize: !Ref LambdaUDFMemorySize
+      ImageConfig:
+        Command:
+          - handler.lambda_handler
+
+Outputs:
+  GlueDatabaseName:
+    Description: Name of the Glue database
+    Value: !Ref TelemetryDatabase
+    Export:
+      Name: !Sub "${AWS::StackName}-GlueDatabaseName"
+
+  GlueCrawlerName:
+    Description: Name of the Glue crawler
+    Value: !Ref TelemetryCrawler
+    Export:
+      Name: !Sub "${AWS::StackName}-GlueCrawlerName"
+
+  SNSTopicArn:
+    Description: ARN of the SNS topic used for notifications
+    Value: !If
+      - UseExistingSNS
+      - !Ref SNSTopicArn
+      - !Ref TelemetryNotificationsTopic
+    Export:
+      Name: !Sub "${AWS::StackName}-SNSTopicArn"
+
+  SQSQueueArn:
+    Description: ARN of the SQS queue
+    Value: !GetAtt CrawlerQueue.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-SQSQueueArn"
+
+  LambdaUDFFunctionName:
+    Description: Name of the Lambda UDF function
+    Value: !Ref AthenaUDF
+    Export:
+      Name: !Sub "${AWS::StackName}-LambdaUDFFunctionName"
+
+  LambdaUDFFunctionArn:
+    Description: ARN of the Lambda UDF function
+    Value: !GetAtt AthenaUDF.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-LambdaUDFFunctionArn"


### PR DESCRIPTION
New CloudFormation template for standing up Athena otel resources. This template will be deployed alongside either the `aws_agent_with_opentelemetry_collector.yml` (otel collector + data store) or `aws_otel_collector_data_store.yml` (just data store). This template stands up the Glue Crawler, Lambda UDF, SNS topic (if required), SQS queue, and related IAM roles. The end result is that otel traces written to S3 data store can be ingested into a Glue data catalog table via a Glue crawler. Athena is able to query this Glue table and can invoke Bedrock models in its queries using the Lambda UDF.