### PR TITLE
Add Generic Agent deployment examples (Docker Compose + Kubernetes)

### DIFF
--- a/examples/generic/docker-compose/minio/.gitignore
+++ b/examples/generic/docker-compose/minio/.gitignore
@@ -1,0 +1,5 @@
+secrets/*
+!secrets/*.example
+!secrets/integrations/
+secrets/integrations/*
+!secrets/integrations/*.example

--- a/examples/generic/docker-compose/minio/README.md
+++ b/examples/generic/docker-compose/minio/README.md
@@ -13,7 +13,7 @@ Deploy the Monte Carlo Generic Agent with [Docker Compose](https://docs.docker.c
 
 Edit `docker-compose.yml` and replace:
 
-- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Settings > Account Information > Agent Service** and copy the **Public endpoint**.
+- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
 - `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
 
 ### 2. Create the token file

--- a/examples/generic/docker-compose/minio/README.md
+++ b/examples/generic/docker-compose/minio/README.md
@@ -1,0 +1,85 @@
+# Docker Compose + MinIO
+
+Deploy the Monte Carlo Generic Agent with [Docker Compose](https://docs.docker.com/compose/) using [MinIO](https://min.io/) for S3-compatible object storage.
+
+## Prerequisites
+
+1. [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
+2. An agent token (`mcd_id` and `mcd_token`) from Monte Carlo — see [Create and Register a Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms).
+
+## Quick Start
+
+### 1. Configure
+
+Edit `docker-compose.yml` and replace:
+
+- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Settings > Account Information > Agent Service** and copy the **Public endpoint**.
+- `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
+
+### 2. Create the token file
+
+[Register a new Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms) in Monte Carlo and generate a key to obtain your `mcd_id` and `mcd_token`, then:
+
+```bash
+mkdir -p secrets/integrations
+cat > secrets/token.json << 'EOF'
+{"mcd_id": "<YOUR_MCD_ID>", "mcd_token": "<YOUR_MCD_TOKEN>"}
+EOF
+chmod 600 secrets/token.json
+```
+
+### 3. Start all services
+
+```bash
+docker compose up -d
+```
+
+This starts MinIO, automatically creates the storage bucket, and launches the agent.
+
+### 4. Verify
+
+Check that the agent is running:
+
+```bash
+docker compose logs -f mcd-agent
+```
+
+Test that the agent can communicate with the Monte Carlo platform:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/test/reachability
+```
+
+A successful response contains `"ok": true`.
+
+You can also browse the MinIO Console at http://localhost:9001 (log in with `minioadmin` and your configured password) to inspect the storage bucket.
+
+> **Note:** MinIO with default credentials is suitable for development and testing only. For production deployments, configure MinIO with proper credentials and TLS, or use a cloud-native storage service.
+
+## Adding Integration Credentials
+
+Place integration credential files in `./secrets/integrations/`. They are mounted read-only into the container at `/etc/secrets/integrations/`.
+
+See the [Self-Hosted Credentials](https://docs.getmontecarlo.com/docs/self-hosted-credentials) documentation for the JSON format for each integration type.
+
+After adding the files, restart the agent:
+
+```bash
+docker compose restart mcd-agent
+```
+
+Then register the integration in Monte Carlo using the CLI:
+
+```bash
+montecarlo integrations add-self-hosted-credentials-v2 \
+  --connection-type <integration> \
+  --self-hosted-credentials-type FILE \
+  --file-path /etc/secrets/integrations/<integration>.json \
+  --name <connection_name>
+```
+
+## Teardown
+
+```bash
+docker compose down -v
+```

--- a/examples/generic/docker-compose/minio/docker-compose.yml
+++ b/examples/generic/docker-compose/minio/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  mcd-agent:
+    image: montecarlodata/agent:latest-generic
+    ports:
+      - "8080:8080"
+    environment:
+      - PORT=8080
+      - BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+      - MCD_AGENT_WRAPPER_TYPE=DOCKER
+      - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
+      - MCD_STORAGE=S3_COMPATIBLE
+      - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
+      - MCD_STORAGE_ACCESS_KEY=minioadmin
+      - MCD_STORAGE_SECRET_KEY=change-me-to-a-secure-password
+      - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
+    volumes:
+      - ./secrets/token.json:/etc/secrets/mcd-agent-token/contents.json:ro
+      - ./secrets/integrations:/etc/secrets/integrations:ro
+    restart: unless-stopped
+    depends_on:
+      create-bucket:
+        condition: service_completed_successfully
+
+  create-bucket:
+    image: quay.io/minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      - MC_HOST_local=http://minioadmin:change-me-to-a-secure-password@minio:9000
+    entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
+
+  minio:
+    image: quay.io/minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=change-me-to-a-secure-password
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  minio-data:

--- a/examples/generic/docker-compose/minio/secrets/integrations/sqlserver.json.example
+++ b/examples/generic/docker-compose/minio/secrets/integrations/sqlserver.json.example
@@ -1,0 +1,5 @@
+{
+  "connect_args": "DRIVER={ODBC Driver 17 for SQL Server};SERVER={<HOST>,<PORT>};UID={<USER>};PWD={<PASSWORD>};",
+  "login_timeout": 15,
+  "query_timeout_in_seconds": 840
+}

--- a/examples/generic/docker-compose/minio/secrets/token.json.example
+++ b/examples/generic/docker-compose/minio/secrets/token.json.example
@@ -1,0 +1,4 @@
+{
+  "mcd_id": "<YOUR_MCD_ID>",
+  "mcd_token": "<YOUR_MCD_TOKEN>"
+}

--- a/examples/generic/kubernetes/minio/.gitignore
+++ b/examples/generic/kubernetes/minio/.gitignore
@@ -1,0 +1,5 @@
+secrets/*
+!secrets/*.example
+!secrets/integrations/
+secrets/integrations/*
+!secrets/integrations/*.example

--- a/examples/generic/kubernetes/minio/README.md
+++ b/examples/generic/kubernetes/minio/README.md
@@ -1,0 +1,125 @@
+# Kubernetes + MinIO
+
+Deploy the Monte Carlo Generic Agent on Kubernetes using [Helm](https://helm.sh/) with [MinIO](https://min.io/) for S3-compatible object storage.
+
+These instructions are platform-agnostic and work on any Kubernetes distribution (EKS, AKS, GKE, k3s, kind, minikube, or on-premises). See the [full documentation](https://docs.getmontecarlo.com/docs/kubernetes) for additional details.
+
+## Prerequisites
+
+1. A running Kubernetes cluster (any distribution).
+2. `kubectl` and `helm` CLI tools installed and configured to access your cluster.
+3. An agent token (`mcd_id` and `mcd_token`) from Monte Carlo — see [Create and Register a Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms).
+
+## Quick Start
+
+### 1. Deploy MinIO
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/monte-carlo-data/hermes-agent/main/environments/local/minio/k8s.yaml
+```
+
+Wait for MinIO to be ready, then create the storage bucket:
+
+```bash
+kubectl port-forward -n minio deploy/minio 9000:9000 9001:9001
+```
+
+Open http://localhost:9001, log in with `minioadmin` / `minioadmin`, and create a bucket called `mcd-agent-storage`.
+
+> **Note:** MinIO with default credentials is suitable for development and testing only. For production deployments, use a cloud-native storage service or configure MinIO with proper credentials, TLS, and persistent storage.
+
+### 2. Create the agent namespace
+
+```bash
+kubectl create namespace mcd-agent
+kubectl label namespace mcd-agent app.kubernetes.io/managed-by=Helm
+kubectl annotate namespace mcd-agent meta.helm.sh/release-name=mcd-agent meta.helm.sh/release-namespace=default
+```
+
+### 3. Create secrets
+
+[Register a new Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms) in Monte Carlo and generate a key to obtain your `mcd_id` and `mcd_token`.
+
+Create the agent token secret:
+
+```bash
+cp secrets/token.json.example secrets/token.json
+# Edit secrets/token.json with your mcd_id and mcd_token
+kubectl create secret generic mcd-agent-token-secret -n mcd-agent \
+  --from-file=contents.json=secrets/token.json
+```
+
+Create the integrations secret (can start empty and be populated later):
+
+```bash
+kubectl create secret generic mcd-integrations-secrets -n mcd-agent \
+  --from-file=empty.json=<(echo '{}')
+```
+
+### 4. Configure and deploy
+
+Edit `values.yaml` and replace `<YOUR_BACKEND_SERVICE_URL>` with the **Public endpoint** from the Monte Carlo app: **Account Information > Agent Service**.
+
+Deploy the agent:
+
+```bash
+helm upgrade --install mcd-agent \
+  oci://registry-1.docker.io/montecarlodata/generic-agent-helm \
+  --version 0.1.0 \
+  -f values.yaml
+```
+
+> Check [Docker Hub](https://hub.docker.com/r/montecarlodata/generic-agent-helm/tags) for the latest chart version.
+
+### 5. Verify
+
+Check the agent pod is running:
+
+```bash
+kubectl get pods -n mcd-agent
+kubectl logs -n mcd-agent -l app=mcd-agent --tail=30
+```
+
+Test that the agent can communicate with the Monte Carlo platform:
+
+```bash
+kubectl exec -n mcd-agent deploy/mcd-agent-deployment -- \
+  curl -s -X POST localhost:8080/api/v1/test/reachability
+```
+
+A successful response contains `"ok": true`.
+
+## Adding Integration Credentials
+
+Replace the integrations secret with one containing your connection details:
+
+```bash
+kubectl delete secret mcd-integrations-secrets -n mcd-agent
+kubectl create secret generic mcd-integrations-secrets -n mcd-agent \
+  --from-file=<integration>.json=secrets/integrations/<integration>.json
+kubectl rollout restart deployment/mcd-agent-deployment -n mcd-agent
+```
+
+You can include multiple integration files using additional `--from-file` flags. See the [Self-Hosted Credentials](https://docs.getmontecarlo.com/docs/self-hosted-credentials) documentation for the JSON format for each integration type.
+
+Then register the integration in Monte Carlo using the CLI:
+
+```bash
+montecarlo integrations add-self-hosted-credentials-v2 \
+  --connection-type <integration> \
+  --self-hosted-credentials-type FILE \
+  --file-path /etc/secrets/integrations/<integration>.json \
+  --name <connection_name>
+```
+
+## Updating the Agent
+
+Update the `--version` flag and `image.tag` in `values.yaml`, then re-run the `helm upgrade` command.
+
+## Teardown
+
+```bash
+helm uninstall mcd-agent
+kubectl delete namespace mcd-agent
+kubectl delete -f https://raw.githubusercontent.com/monte-carlo-data/hermes-agent/main/environments/local/minio/k8s.yaml
+```

--- a/examples/generic/kubernetes/minio/secrets/integrations/sqlserver.json.example
+++ b/examples/generic/kubernetes/minio/secrets/integrations/sqlserver.json.example
@@ -1,0 +1,5 @@
+{
+  "connect_args": "DRIVER={ODBC Driver 17 for SQL Server};SERVER={<HOST>,<PORT>};UID={<USER>};PWD={<PASSWORD>};",
+  "login_timeout": 15,
+  "query_timeout_in_seconds": 840
+}

--- a/examples/generic/kubernetes/minio/secrets/token.json.example
+++ b/examples/generic/kubernetes/minio/secrets/token.json.example
@@ -1,0 +1,4 @@
+{
+  "mcd_id": "<YOUR_MCD_ID>",
+  "mcd_token": "<YOUR_MCD_TOKEN>"
+}

--- a/examples/generic/kubernetes/minio/values.yaml
+++ b/examples/generic/kubernetes/minio/values.yaml
@@ -1,0 +1,16 @@
+namespace: mcd-agent
+replicaCount: 1
+
+image:
+  pullPolicy: Always
+  tag: "latest-generic"
+
+container:
+  backendServiceUrl: "<YOUR_BACKEND_SERVICE_URL>"
+  storageBucketName: "mcd-agent-storage"
+  storageType: "S3_COMPATIBLE"
+  storageEndpointUrl: "http://minio-api.minio.svc.cluster.local:9000"
+  storageAccessKey: "minioadmin"
+  storageSecretKey: "minioadmin"
+
+skipExternalSecrets: true


### PR DESCRIPTION
## Summary

- **Docker Compose + MinIO** (`examples/generic/docker-compose/minio/`): Self-contained example using Docker Compose with MinIO for S3-compatible storage. Includes auto bucket creation, production agent image, and credential templates.
- **Kubernetes + MinIO** (`examples/generic/kubernetes/minio/`): Helm-based example for deploying on any Kubernetes cluster with MinIO. Includes ready-to-use `values.yaml` and step-by-step README.
- Both examples include `.gitignore` to protect real secrets and `.example` templates for agent token and SQL Server integration credentials.

## Test plan

- [x] Docker Compose example tested locally — MinIO healthy, bucket auto-created, agent started, healthcheck OK, reachability test passed (`"ok": true`)
- [x] SQL Server integration credentials tested end-to-end through the Docker Compose deployment — agent executed `sql-server/_execute_and_fetch_all` operations successfully, all results published to backend with 200 responses
- [ ] Validate Kubernetes example on a local cluster (k3s/kind)

## Notes

- Companion docs-website changes (new `docker-compose.md` page, navigation updates) tracked separately on `v3.5_generic_agent_docs` branch in `docs-website` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)