### PR TITLE
Add proxy and TLS inspection examples for generic agent

### DIFF
--- a/examples/generic/docker-compose/proxy/.gitignore
+++ b/examples/generic/docker-compose/proxy/.gitignore
@@ -1,0 +1,5 @@
+secrets/*
+!secrets/*.example
+!secrets/integrations/
+secrets/integrations/*
+!secrets/integrations/*.example

--- a/examples/generic/docker-compose/proxy/README.md
+++ b/examples/generic/docker-compose/proxy/README.md
@@ -1,0 +1,95 @@
+# Docker Compose + Forward Proxy
+
+Route Monte Carlo Generic Agent traffic through a [Squid](http://www.squid-cache.org/) forward proxy so you can see exactly which hosts and ports the agent connects to.
+
+## Prerequisites
+
+1. [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
+2. An agent token (`mcd_id` and `mcd_token`) from Monte Carlo — see [Create and Register a Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms).
+
+## Quick Start
+
+### 1. Configure
+
+Edit `docker-compose.yml` and replace:
+
+- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
+- `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
+
+### 2. Create the token file
+
+[Register a new Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms) in Monte Carlo and generate a key to obtain your `mcd_id` and `mcd_token`, then:
+
+```bash
+mkdir -p secrets/integrations
+cat > secrets/token.json << 'EOF'
+{"mcd_id": "<YOUR_MCD_ID>", "mcd_token": "<YOUR_MCD_TOKEN>"}
+EOF
+chmod 600 secrets/token.json
+```
+
+### 3. Start all services
+
+```bash
+docker compose up -d
+```
+
+This starts the Squid proxy, MinIO, automatically creates the storage bucket, and launches the agent with `HTTP_PROXY` and `HTTPS_PROXY` pointed at Squid.
+
+### 4. View proxy logs
+
+```bash
+docker compose exec squid tail -f /var/log/squid/access.log
+```
+
+All outbound HTTP/HTTPS connections from the agent are logged here.
+
+### 5. Verify
+
+Check that the agent is running and can reach Monte Carlo through the proxy:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/test/reachability
+```
+
+A successful response contains `"ok": true`.
+
+## Reading the Access Logs
+
+Squid logs every connection the agent makes. For HTTPS traffic you will see `CONNECT` entries like:
+
+```
+1718300000.000      1 172.18.0.4 TCP_TUNNEL/200 0 CONNECT artemis.getmontecarlo.com:443 - HIER_DIRECT/1.2.3.4 -
+```
+
+This tells you the agent opened a TLS tunnel to `artemis.getmontecarlo.com` on port 443. Because the traffic is encrypted, Squid only records the host and port — not the request path or body.
+
+> **Note:** This setup provides connection-level visibility only (destination hosts and ports). If you need to inspect the actual request/response content (URLs, headers, and payloads), see the [tls-inspection](../tls-inspection/) example which uses mitmproxy with a browser-based UI.
+
+## Adding Integration Credentials
+
+Place integration credential files in `./secrets/integrations/`. They are mounted read-only into the container at `/etc/secrets/integrations/`.
+
+See the [Self-Hosted Credentials](https://docs.getmontecarlo.com/docs/self-hosted-credentials) documentation for the JSON format for each integration type.
+
+After adding the files, restart the agent:
+
+```bash
+docker compose restart mcd-agent
+```
+
+Then register the integration in Monte Carlo using the CLI:
+
+```bash
+montecarlo integrations add-self-hosted-credentials-v2 \
+  --connection-type <integration> \
+  --self-hosted-credentials-type FILE \
+  --file-path /etc/secrets/integrations/<integration>.json \
+  --name <connection_name>
+```
+
+## Teardown
+
+```bash
+docker compose down -v
+```

--- a/examples/generic/docker-compose/proxy/docker-compose.yml
+++ b/examples/generic/docker-compose/proxy/docker-compose.yml
@@ -15,13 +15,26 @@ services:
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
+      - HTTPS_PROXY=http://squid:3128
+      - HTTP_PROXY=http://squid:3128
+      - NO_PROXY=minio,localhost,127.0.0.1
     volumes:
       - ./secrets/token.json:/etc/secrets/mcd-agent-token/contents.json:ro
       - ./secrets/integrations:/etc/secrets/integrations:ro
     restart: unless-stopped
     depends_on:
+      squid:
+        condition: service_started
       create-bucket:
         condition: service_completed_successfully
+
+  squid:
+    image: ubuntu/squid:latest
+    ports:
+      - "3128:3128"
+    volumes:
+      - ./squid.conf:/etc/squid/squid.conf:ro
+    restart: unless-stopped
 
   create-bucket:
     image: quay.io/minio/mc:latest

--- a/examples/generic/docker-compose/proxy/secrets/integrations/sqlserver.json.example
+++ b/examples/generic/docker-compose/proxy/secrets/integrations/sqlserver.json.example
@@ -1,0 +1,5 @@
+{
+  "connect_args": "DRIVER={ODBC Driver 17 for SQL Server};SERVER={<HOST>,<PORT>};UID={<USER>};PWD={<PASSWORD>};",
+  "login_timeout": 15,
+  "query_timeout_in_seconds": 840
+}

--- a/examples/generic/docker-compose/proxy/secrets/token.json.example
+++ b/examples/generic/docker-compose/proxy/secrets/token.json.example
@@ -1,0 +1,4 @@
+{
+  "mcd_id": "<YOUR_MCD_ID>",
+  "mcd_token": "<YOUR_MCD_TOKEN>"
+}

--- a/examples/generic/docker-compose/proxy/squid.conf
+++ b/examples/generic/docker-compose/proxy/squid.conf
@@ -1,0 +1,12 @@
+http_port 3128
+
+acl SSL_ports port 443
+acl Safe_ports port 80 443
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow all
+
+access_log /var/log/squid/access.log squid
+cache deny all

--- a/examples/generic/docker-compose/tls-inspection/.gitignore
+++ b/examples/generic/docker-compose/tls-inspection/.gitignore
@@ -1,0 +1,6 @@
+secrets/*
+!secrets/*.example
+!secrets/integrations/
+secrets/integrations/*
+!secrets/integrations/*.example
+certs/

--- a/examples/generic/docker-compose/tls-inspection/README.md
+++ b/examples/generic/docker-compose/tls-inspection/README.md
@@ -1,0 +1,118 @@
+# Docker Compose + TLS Inspection
+
+Inspect the full content of HTTPS traffic from the Monte Carlo Generic Agent using [mitmproxy](https://mitmproxy.org/). This lets you audit exactly what data the agent sends to Monte Carlo — complete URLs, request/response headers, and payloads — through a browser-based UI.
+
+## Prerequisites
+
+1. [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
+2. [OpenSSL](https://www.openssl.org/) installed (for generating the CA certificate).
+3. An agent token (`mcd_id` and `mcd_token`) from Monte Carlo — see [Create and Register a Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms).
+
+## Quick Start
+
+### 1. Generate CA certificate
+
+```bash
+./generate-ca.sh
+```
+
+This creates a CA certificate that mitmproxy uses to intercept TLS connections. The agent is configured to trust this CA.
+
+### 2. Configure
+
+Edit `docker-compose.yml` and replace:
+
+- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
+- `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
+
+### 3. Create the token file
+
+[Register a new Generic Agent](https://docs.getmontecarlo.com/docs/generic-agent-platforms) in Monte Carlo and generate a key to obtain your `mcd_id` and `mcd_token`, then:
+
+```bash
+mkdir -p secrets/integrations
+cat > secrets/token.json << 'EOF'
+{"mcd_id": "<YOUR_MCD_ID>", "mcd_token": "<YOUR_MCD_TOKEN>"}
+EOF
+chmod 600 secrets/token.json
+```
+
+### 4. Start all services
+
+```bash
+docker compose up -d
+```
+
+This starts MinIO, creates the storage bucket, launches mitmproxy, and starts the agent with proxy settings.
+
+### 5. Open the mitmproxy web UI
+
+Open http://localhost:8081 in your browser and log in with password `mitmproxy` (configurable via `web_password` in `docker-compose.yml`). All HTTPS requests from the agent appear in real time. Click any request to inspect:
+
+- Full URL and HTTP method
+- Request and response headers
+- Request and response bodies (JSON payloads)
+- Timing details
+
+### 6. Verify
+
+Test that the agent is running and can communicate through the proxy:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/test/reachability
+```
+
+A successful response contains `"ok": true`. You should also see the request appear in the mitmproxy web UI.
+
+## How It Works
+
+[mitmproxy](https://mitmproxy.org/) performs TLS interception by acting as a man-in-the-middle proxy:
+
+1. The agent sends HTTPS requests through the proxy.
+2. mitmproxy terminates the TLS connection using a dynamically generated certificate signed by the local CA.
+3. mitmproxy records the full request and response (headers, body, timing).
+4. mitmproxy opens a new TLS connection to the upstream server and forwards the request.
+
+The agent trusts the local CA because `mitmproxy-ca-cert.pem` is mounted into its certificate store and `update-ca-certificates` is run at startup. The `REQUESTS_CA_BUNDLE` environment variable ensures Python's `requests` library also uses the updated store.
+
+The included `stream_sse.py` addon ensures that Server-Sent Events (SSE) responses are streamed through the proxy without buffering. Without it, mitmproxy would buffer the long-lived SSE connection and prevent the agent from receiving real-time events.
+
+## Security Note
+
+The CA private key (`certs/mitmproxy-ca.pem`) can sign certificates for **any** domain. Keep it secure and use this setup for inspection and auditing purposes only. Do not distribute the CA key outside your environment.
+
+> For basic connection-level logging (destination hosts and ports) without TLS interception, see the [proxy](../proxy/) example.
+
+## Adding Integration Credentials
+
+Place integration credential files in `./secrets/integrations/`. They are mounted read-only into the container at `/etc/secrets/integrations/`.
+
+See the [Self-Hosted Credentials](https://docs.getmontecarlo.com/docs/self-hosted-credentials) documentation for the JSON format for each integration type.
+
+After adding the files, restart the agent:
+
+```bash
+docker compose restart mcd-agent
+```
+
+Then register the integration in Monte Carlo using the CLI:
+
+```bash
+montecarlo integrations add-self-hosted-credentials-v2 \
+  --connection-type <integration> \
+  --self-hosted-credentials-type FILE \
+  --file-path /etc/secrets/integrations/<integration>.json \
+  --name <connection_name>
+```
+
+## Teardown
+
+```bash
+docker compose down -v
+```
+
+This removes all containers, volumes, and networks. The generated CA certificate in `certs/` is not removed automatically — delete it manually if no longer needed:
+
+```bash
+rm -rf certs/
+```

--- a/examples/generic/docker-compose/tls-inspection/docker-compose.yml
+++ b/examples/generic/docker-compose/tls-inspection/docker-compose.yml
@@ -12,16 +12,40 @@ services:
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
       - MCD_STORAGE_ACCESS_KEY=minioadmin
       - MCD_STORAGE_SECRET_KEY=change-me-to-a-secure-password
+      - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
-      - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
+      - HTTPS_PROXY=http://mitmproxy:3128
+      - HTTP_PROXY=http://mitmproxy:3128
+      - NO_PROXY=minio,localhost,127.0.0.1
+      - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
     volumes:
+      - ./certs/mitmproxy-ca-cert.pem:/usr/local/share/ca-certificates/mitmproxy-ca.crt:ro
       - ./secrets/token.json:/etc/secrets/mcd-agent-token/contents.json:ro
       - ./secrets/integrations:/etc/secrets/integrations:ro
+    command: >-
+      /bin/sh -c "
+      update-ca-certificates 2>/dev/null;
+      . .venv/bin/activate &&
+      exec gunicorn --bind :$$PORT --workers $$GUNICORN_WORKERS --threads $$GUNICORN_THREADS --timeout $$GUNICORN_TIMEOUT hermes.agent.main:app
+      "
     restart: unless-stopped
     depends_on:
+      mitmproxy:
+        condition: service_started
       create-bucket:
         condition: service_completed_successfully
+
+  mitmproxy:
+    image: mitmproxy/mitmproxy
+    command: mitmweb --web-host 0.0.0.0 --listen-port 3128 --no-web-open-browser --set web_password=mitmproxy -s /home/mitmproxy/stream_sse.py
+    ports:
+      - "3128:3128"
+      - "8081:8081"
+    volumes:
+      - ./certs:/home/mitmproxy/.mitmproxy
+      - ./stream_sse.py:/home/mitmproxy/stream_sse.py:ro
+    restart: unless-stopped
 
   create-bucket:
     image: quay.io/minio/mc:latest

--- a/examples/generic/docker-compose/tls-inspection/generate-ca.sh
+++ b/examples/generic/docker-compose/tls-inspection/generate-ca.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p certs
+openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 \
+  -subj "/CN=MCD Traffic Inspection CA" \
+  -keyout certs/ca.key -out certs/mitmproxy-ca-cert.pem 2>/dev/null
+cat certs/mitmproxy-ca-cert.pem certs/ca.key > certs/mitmproxy-ca.pem
+rm certs/ca.key
+chmod 644 certs/mitmproxy-ca-cert.pem
+chmod 600 certs/mitmproxy-ca.pem
+echo "CA certificate generated in certs/"

--- a/examples/generic/docker-compose/tls-inspection/secrets/integrations/sqlserver.json.example
+++ b/examples/generic/docker-compose/tls-inspection/secrets/integrations/sqlserver.json.example
@@ -1,0 +1,5 @@
+{
+  "connect_args": "DRIVER={ODBC Driver 17 for SQL Server};SERVER={<HOST>,<PORT>};UID={<USER>};PWD={<PASSWORD>};",
+  "login_timeout": 15,
+  "query_timeout_in_seconds": 840
+}

--- a/examples/generic/docker-compose/tls-inspection/secrets/token.json.example
+++ b/examples/generic/docker-compose/tls-inspection/secrets/token.json.example
@@ -1,0 +1,4 @@
+{
+  "mcd_id": "<YOUR_MCD_ID>",
+  "mcd_token": "<YOUR_MCD_TOKEN>"
+}

--- a/examples/generic/docker-compose/tls-inspection/stream_sse.py
+++ b/examples/generic/docker-compose/tls-inspection/stream_sse.py
@@ -1,0 +1,7 @@
+"""mitmproxy addon: stream only SSE responses to avoid buffering long-lived connections."""
+
+
+def responseheaders(flow):
+    content_type = flow.response.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        flow.response.stream = True


### PR DESCRIPTION
## Summary

- **proxy/** — Squid forward proxy example showing connection-level traffic (destination hosts and ports). Useful for verifying the agent only connects to expected endpoints.
- **tls-inspection/** — mitmproxy example with TLS interception and browser-based UI for full payload inspection (URLs, headers, request/response bodies). Includes `stream_sse.py` addon to handle SSE without buffering.
- Added `MCD_OPS_RUNNER_THREAD_COUNT=18` and `MCD_PUBLISHER_THREAD_COUNT=3` to all Docker Compose examples to match Helm chart defaults.

## Test plan

- [x] Docker Compose proxy: Squid started, agent routed traffic through proxy, access logs show `CONNECT` entries to Monte Carlo backend
- [x] Docker Compose TLS inspection: mitmproxy started, agent connected through proxy with custom CA trust, SSE events flowing, web UI shows full request/response payloads
- [x] SQL Server integration tested end-to-end through TLS inspection proxy

## Notes

- Kubernetes equivalents are in a separate PR: #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)