### PR TITLE
Add Kubernetes proxy and TLS inspection examples

### DIFF
--- a/examples/generic/kubernetes/minio/README.md
+++ b/examples/generic/kubernetes/minio/README.md
@@ -65,7 +65,7 @@ Deploy the agent:
 ```bash
 helm upgrade --install mcd-agent \
   oci://registry-1.docker.io/montecarlodata/generic-agent-helm \
-  --version 0.1.0 \
+  --version 0.0.5 \
   -f values.yaml
 ```
 

--- a/examples/generic/kubernetes/proxy/.gitignore
+++ b/examples/generic/kubernetes/proxy/.gitignore
@@ -1,0 +1,5 @@
+secrets/*
+!secrets/*.example
+!secrets/integrations/
+secrets/integrations/*
+!secrets/integrations/*.example

--- a/examples/generic/kubernetes/proxy/README.md
+++ b/examples/generic/kubernetes/proxy/README.md
@@ -1,0 +1,73 @@
+# Kubernetes + Forward Proxy
+
+Route Monte Carlo Generic Agent traffic through a [Squid](http://www.squid-cache.org/) forward proxy so you can see exactly which hosts and ports the agent connects to.
+
+These instructions build on the [Kubernetes + MinIO](../minio/) example. See the [full documentation](https://docs.getmontecarlo.com/docs/kubernetes) for additional details.
+
+## Prerequisites
+
+1. A running Kubernetes cluster with the agent deployed using the [minio](../minio/) example (or equivalent).
+2. `kubectl` and `helm` CLI tools installed and configured.
+3. The Helm chart version must support `container.extraEnv` (check the chart's README).
+
+## Quick Start
+
+### 1. Deploy Squid
+
+```bash
+kubectl apply -f squid.yaml
+```
+
+This creates a Squid proxy Deployment, Service, and ConfigMap in the `mcd-agent` namespace.
+
+### 2. Configure and deploy the agent
+
+Edit `values.yaml` and replace `<YOUR_BACKEND_SERVICE_URL>` with the **Public endpoint** from the Monte Carlo app: **Account Information > Agent Service**.
+
+Deploy (or upgrade) the agent:
+
+```bash
+helm upgrade --install mcd-agent \
+  oci://registry-1.docker.io/montecarlodata/generic-agent-helm \
+  --version 0.0.5 \
+  -f values.yaml
+```
+
+### 3. View proxy logs
+
+```bash
+kubectl exec -n mcd-agent deploy/squid -- tail -f /var/log/squid/access.log
+```
+
+All outbound HTTP/HTTPS connections from the agent are logged here.
+
+### 4. Verify
+
+```bash
+kubectl exec -n mcd-agent deploy/mcd-agent-deployment -- \
+  curl -s -X POST localhost:8080/api/v1/test/reachability
+```
+
+A successful response contains `"ok": true`.
+
+## Reading the Access Logs
+
+Squid logs every connection the agent makes. For HTTPS traffic you will see `CONNECT` entries like:
+
+```
+1718300000.000      1 10.42.0.5 TCP_TUNNEL/200 0 CONNECT artemis.getmontecarlo.com:443 - HIER_DIRECT/1.2.3.4 -
+```
+
+This tells you the agent opened a TLS tunnel to `artemis.getmontecarlo.com` on port 443. Because the traffic is encrypted, Squid only records the host and port — not the request path or body.
+
+> **Note:** This setup provides connection-level visibility only (destination hosts and ports). If you need to inspect the actual request/response content (URLs, headers, and payloads), see the [tls-inspection](../tls-inspection/) example which uses mitmproxy with a browser-based UI.
+
+## Teardown
+
+Remove the Squid proxy:
+
+```bash
+kubectl delete -f squid.yaml
+```
+
+To remove the agent as well, see the [minio example teardown](../minio/#teardown).

--- a/examples/generic/kubernetes/proxy/secrets/integrations/sqlserver.json.example
+++ b/examples/generic/kubernetes/proxy/secrets/integrations/sqlserver.json.example
@@ -1,0 +1,5 @@
+{
+  "connect_args": "DRIVER={ODBC Driver 17 for SQL Server};SERVER={<HOST>,<PORT>};UID={<USER>};PWD={<PASSWORD>};",
+  "login_timeout": 15,
+  "query_timeout_in_seconds": 840
+}

--- a/examples/generic/kubernetes/proxy/secrets/token.json.example
+++ b/examples/generic/kubernetes/proxy/secrets/token.json.example
@@ -1,0 +1,4 @@
+{
+  "mcd_id": "<YOUR_MCD_ID>",
+  "mcd_token": "<YOUR_MCD_TOKEN>"
+}

--- a/examples/generic/kubernetes/proxy/squid.yaml
+++ b/examples/generic/kubernetes/proxy/squid.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: squid-config
+  namespace: mcd-agent
+data:
+  squid.conf: |
+    http_port 3128
+
+    acl SSL_ports port 443
+    acl Safe_ports port 80 443
+    acl CONNECT method CONNECT
+
+    http_access deny !Safe_ports
+    http_access deny CONNECT !SSL_ports
+    http_access allow all
+
+    access_log /var/log/squid/access.log squid
+    cache deny all
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: squid
+  namespace: mcd-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: squid
+  template:
+    metadata:
+      labels:
+        app: squid
+    spec:
+      containers:
+        - name: squid
+          image: ubuntu/squid:latest
+          ports:
+            - containerPort: 3128
+          volumeMounts:
+            - name: squid-config
+              mountPath: /etc/squid/squid.conf
+              subPath: squid.conf
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: squid-config
+          configMap:
+            name: squid-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: squid
+  namespace: mcd-agent
+spec:
+  selector:
+    app: squid
+  ports:
+    - port: 3128
+      targetPort: 3128

--- a/examples/generic/kubernetes/proxy/values.yaml
+++ b/examples/generic/kubernetes/proxy/values.yaml
@@ -12,6 +12,13 @@ container:
   storageEndpointUrl: "http://minio-api.minio.svc.cluster.local:9000"
   storageAccessKey: "minioadmin"
   storageSecretKey: "minioadmin"
+  extraEnv:
+    - name: HTTPS_PROXY
+      value: "http://squid.mcd-agent.svc.cluster.local:3128"
+    - name: HTTP_PROXY
+      value: "http://squid.mcd-agent.svc.cluster.local:3128"
+    - name: NO_PROXY
+      value: "minio-api.minio.svc.cluster.local,localhost,127.0.0.1"
 
 skipExternalSecrets: true
 

--- a/examples/generic/kubernetes/tls-inspection/.gitignore
+++ b/examples/generic/kubernetes/tls-inspection/.gitignore
@@ -1,0 +1,6 @@
+certs/
+secrets/*
+!secrets/*.example
+!secrets/integrations/
+secrets/integrations/*
+!secrets/integrations/*.example

--- a/examples/generic/kubernetes/tls-inspection/README.md
+++ b/examples/generic/kubernetes/tls-inspection/README.md
@@ -1,0 +1,110 @@
+# Kubernetes + TLS Inspection
+
+Inspect the full content of HTTPS traffic from the Monte Carlo Generic Agent using [mitmproxy](https://mitmproxy.org/). This lets you audit exactly what data the agent sends to Monte Carlo — complete URLs, request/response headers, and payloads — through a browser-based UI.
+
+These instructions build on the [Kubernetes + MinIO](../minio/) example. See the [full documentation](https://docs.getmontecarlo.com/docs/kubernetes) for additional details.
+
+## Prerequisites
+
+1. A running Kubernetes cluster with the agent deployed using the [minio](../minio/) example (or equivalent).
+2. `kubectl` and `helm` CLI tools installed and configured.
+3. [OpenSSL](https://www.openssl.org/) installed (for generating the CA certificate).
+4. The Helm chart version must support `firewallCa` and `container.extraEnv` (check the chart's README).
+
+## Quick Start
+
+### 1. Generate CA certificate
+
+```bash
+./generate-ca.sh
+```
+
+This creates a CA certificate that mitmproxy uses to intercept TLS connections.
+
+### 2. Create the mitmproxy secret
+
+```bash
+kubectl create secret generic mitmproxy-ca -n mcd-agent \
+  --from-file=mitmproxy-ca.pem=certs/mitmproxy-ca.pem
+```
+
+### 3. Deploy mitmproxy
+
+```bash
+kubectl apply -f mitmproxy.yaml
+```
+
+### 4. Configure and deploy the agent
+
+Edit `values.yaml`:
+- Replace `<YOUR_BACKEND_SERVICE_URL>` with the **Public endpoint** from the Monte Carlo app: **Account Information > Agent Service**.
+- Replace `<PASTE_CA_CERT_PEM_HERE>` under `firewallCa.cert` with the contents of `certs/ca-cert.pem`.
+
+Deploy (or upgrade) the agent:
+
+```bash
+helm upgrade --install mcd-agent \
+  oci://registry-1.docker.io/montecarlodata/generic-agent-helm \
+  --version 0.0.5 \
+  -f values.yaml
+```
+
+The Helm chart automatically builds a combined CA bundle and sets `REQUESTS_CA_BUNDLE` on the agent when `firewallCa.cert` is configured.
+
+### 5. Access the mitmproxy web UI
+
+```bash
+kubectl port-forward -n mcd-agent svc/mitmproxy 8081:8081
+```
+
+Open http://localhost:8081 in your browser and log in with password `mitmproxy`. All HTTPS requests from the agent appear in real time. Click any request to inspect:
+
+- Full URL and HTTP method
+- Request and response headers
+- Request and response bodies (JSON payloads)
+- Timing details
+
+### 6. Verify
+
+```bash
+kubectl exec -n mcd-agent deploy/mcd-agent-deployment -- \
+  curl -s -X POST localhost:8080/api/v1/test/reachability
+```
+
+A successful response contains `"ok": true`. You should also see the request appear in the mitmproxy web UI.
+
+## How It Works
+
+[mitmproxy](https://mitmproxy.org/) performs TLS interception by acting as a man-in-the-middle proxy:
+
+1. The agent sends HTTPS requests through the proxy (configured via `HTTPS_PROXY`).
+2. mitmproxy terminates the TLS connection using a dynamically generated certificate signed by the local CA.
+3. mitmproxy records the full request and response (headers, body, timing).
+4. mitmproxy opens a new TLS connection to the upstream server and forwards the request.
+
+The agent trusts the local CA through the Helm chart's `firewallCa` feature, which uses an init container to merge the custom CA with system certificates into a combined bundle.
+
+The included `stream_sse.py` addon (deployed as a ConfigMap) ensures that Server-Sent Events (SSE) responses are streamed through the proxy without buffering. Without it, mitmproxy would buffer the long-lived SSE connection and prevent the agent from receiving real-time events.
+
+## Security Note
+
+The CA private key (inside the `mitmproxy-ca` secret) can sign certificates for **any** domain. Keep it secure and use this setup for inspection and auditing purposes only.
+
+> For basic connection-level logging (destination hosts and ports) without TLS interception, see the [proxy](../proxy/) example.
+
+## Teardown
+
+Remove mitmproxy and its secret:
+
+```bash
+kubectl delete -f mitmproxy.yaml
+kubectl delete secret mitmproxy-ca -n mcd-agent
+```
+
+Delete the generated certificates:
+
+```bash
+rm -rf certs/
+```
+
+To remove the agent as well, see the [minio example teardown](../minio/#teardown).

--- a/examples/generic/kubernetes/tls-inspection/generate-ca.sh
+++ b/examples/generic/kubernetes/tls-inspection/generate-ca.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p certs
+openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 \
+  -subj "/CN=MCD Traffic Inspection CA" \
+  -keyout certs/ca.key -out certs/ca-cert.pem 2>/dev/null
+cat certs/ca-cert.pem certs/ca.key > certs/mitmproxy-ca.pem
+rm certs/ca.key
+chmod 644 certs/ca-cert.pem
+chmod 600 certs/mitmproxy-ca.pem
+echo "CA certificate generated in certs/"
+echo ""
+echo "Next steps:"
+echo "  1. Paste the contents of certs/ca-cert.pem into values.yaml under firewallCa.cert"
+echo "  2. Create the mitmproxy secret:"
+echo "     kubectl create secret generic mitmproxy-ca -n mcd-agent --from-file=mitmproxy-ca.pem=certs/mitmproxy-ca.pem"

--- a/examples/generic/kubernetes/tls-inspection/mitmproxy.yaml
+++ b/examples/generic/kubernetes/tls-inspection/mitmproxy.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mitmproxy-addons
+  namespace: mcd-agent
+data:
+  stream_sse.py: |
+    """mitmproxy addon: stream only SSE responses to avoid buffering long-lived connections."""
+
+    def responseheaders(flow):
+        content_type = flow.response.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            flow.response.stream = True
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mitmproxy
+  namespace: mcd-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mitmproxy
+  template:
+    metadata:
+      labels:
+        app: mitmproxy
+    spec:
+      initContainers:
+        - name: copy-ca
+          image: alpine:3.21
+          command:
+            - sh
+            - -c
+            - cp /ca-secret/mitmproxy-ca.pem /mitmproxy-confdir/mitmproxy-ca.pem
+          volumeMounts:
+            - name: mitmproxy-ca-secret
+              mountPath: /ca-secret
+              readOnly: true
+            - name: mitmproxy-confdir
+              mountPath: /mitmproxy-confdir
+      containers:
+        - name: mitmproxy
+          image: mitmproxy/mitmproxy
+          command:
+            - mitmweb
+            - --web-host
+            - "0.0.0.0"
+            - --listen-port
+            - "3128"
+            - --no-web-open-browser
+            - --set
+            - web_password=mitmproxy
+            - -s
+            - /addons/stream_sse.py
+          ports:
+            - containerPort: 3128
+              name: proxy
+            - containerPort: 8081
+              name: web-ui
+          volumeMounts:
+            - name: mitmproxy-confdir
+              mountPath: /root/.mitmproxy
+            - name: mitmproxy-addons
+              mountPath: /addons
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: mitmproxy-ca-secret
+          secret:
+            secretName: mitmproxy-ca
+        - name: mitmproxy-confdir
+          emptyDir: {}
+        - name: mitmproxy-addons
+          configMap:
+            name: mitmproxy-addons
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mitmproxy
+  namespace: mcd-agent
+spec:
+  selector:
+    app: mitmproxy
+  ports:
+    - port: 3128
+      targetPort: 3128
+      name: proxy
+    - port: 8081
+      targetPort: 8081
+      name: web-ui

--- a/examples/generic/kubernetes/tls-inspection/secrets/integrations/sqlserver.json.example
+++ b/examples/generic/kubernetes/tls-inspection/secrets/integrations/sqlserver.json.example
@@ -1,0 +1,5 @@
+{
+  "connect_args": "DRIVER={ODBC Driver 17 for SQL Server};SERVER={<HOST>,<PORT>};UID={<USER>};PWD={<PASSWORD>};",
+  "login_timeout": 15,
+  "query_timeout_in_seconds": 840
+}

--- a/examples/generic/kubernetes/tls-inspection/secrets/token.json.example
+++ b/examples/generic/kubernetes/tls-inspection/secrets/token.json.example
@@ -1,0 +1,4 @@
+{
+  "mcd_id": "<YOUR_MCD_ID>",
+  "mcd_token": "<YOUR_MCD_TOKEN>"
+}

--- a/examples/generic/kubernetes/tls-inspection/values.yaml
+++ b/examples/generic/kubernetes/tls-inspection/values.yaml
@@ -12,6 +12,19 @@ container:
   storageEndpointUrl: "http://minio-api.minio.svc.cluster.local:9000"
   storageAccessKey: "minioadmin"
   storageSecretKey: "minioadmin"
+  extraEnv:
+    - name: HTTPS_PROXY
+      value: "http://mitmproxy.mcd-agent.svc.cluster.local:3128"
+    - name: HTTP_PROXY
+      value: "http://mitmproxy.mcd-agent.svc.cluster.local:3128"
+    - name: NO_PROXY
+      value: "minio-api.minio.svc.cluster.local,localhost,127.0.0.1"
+
+# The firewallCa feature automatically builds a combined CA bundle and sets
+# REQUESTS_CA_BUNDLE on the agent. Paste the contents of certs/ca-cert.pem here.
+firewallCa:
+  cert: |
+    <PASTE_CA_CERT_PEM_HERE>
 
 skipExternalSecrets: true
 


### PR DESCRIPTION
## Summary

- **kubernetes/proxy/** — Squid forward proxy deployed as a K8s Deployment + Service. Uses Helm `container.extraEnv` for `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` settings. Shows connection-level traffic (destination hosts and ports).
- **kubernetes/tls-inspection/** — mitmproxy with TLS interception and browser-based UI for full payload inspection. Uses Helm `firewallCa.cert` for automatic CA trust and `container.extraEnv` for proxy settings. Includes `stream_sse.py` addon via ConfigMap to handle SSE streams without buffering.
- Updated all K8s example `values.yaml` files with `nodeSelector` for Apple Silicon, `logsCollector.containerRuntimeLogPath` for k3s, and chart version `0.0.5`.

## Test plan

- [x] K8s proxy: Squid deployed, agent routed traffic through proxy, access logs show `CONNECT` entries to Monte Carlo backend
- [x] K8s TLS inspection: mitmproxy deployed with custom CA, agent connected through proxy with `firewallCa` trust, SSE events flowing, mitmproxy web UI accessible via port-forward, full request/response payloads visible
- [x] Logs collector working with `containerRuntimeLogPath` fix for k3s
- [x] Metrics collector running normally
- [x] Tested on Rancher Desktop (k3s, arm64) with Helm chart v0.0.5

## Dependencies

- Requires Helm chart v0.0.5+ with `container.extraEnv`, `firewallCa`, and `extraVolumeMounts` support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)