### PR TITLE
Extract environment-specific values to .env file

### DIFF
--- a/examples/generic/docker-compose/minio/.env.example
+++ b/examples/generic/docker-compose/minio/.env.example
@@ -1,0 +1,3 @@
+BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=change-me-to-a-secure-password

--- a/examples/generic/docker-compose/minio/.env.example
+++ b/examples/generic/docker-compose/minio/.env.example
@@ -1,5 +1,5 @@
-# Optional: override the agent image tag (defaults to latest-generic)
-# AGENT_IMAGE_TAG=latest-generic
+# Optional: pin the agent image to a specific version (defaults to latest-generic)
+# AGENT_IMAGE_TAG=0.0.8-generic
 
 BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
 MINIO_ROOT_USER=minioadmin

--- a/examples/generic/docker-compose/minio/.env.example
+++ b/examples/generic/docker-compose/minio/.env.example
@@ -1,3 +1,6 @@
+# Optional: override the agent image tag (defaults to latest-generic)
+# AGENT_IMAGE_TAG=latest-generic
+
 BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=change-me-to-a-secure-password

--- a/examples/generic/docker-compose/minio/.gitignore
+++ b/examples/generic/docker-compose/minio/.gitignore
@@ -1,3 +1,4 @@
+.env
 secrets/*
 !secrets/*.example
 !secrets/integrations/

--- a/examples/generic/docker-compose/minio/README.md
+++ b/examples/generic/docker-compose/minio/README.md
@@ -11,10 +11,18 @@ Deploy the Monte Carlo Generic Agent with [Docker Compose](https://docs.docker.c
 
 ### 1. Configure
 
-Edit `docker-compose.yml` and replace:
+Copy the example environment file and fill in your values:
 
-- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
-- `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set:
+
+- `BACKEND_SERVICE_URL` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
+- `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` — credentials for MinIO.
+
+Docker Compose automatically reads `.env` when you start the stack.
 
 ### 2. Create the token file
 
@@ -52,7 +60,7 @@ curl -s -X POST http://localhost:8080/api/v1/test/reachability
 
 A successful response contains `"ok": true`.
 
-You can also browse the MinIO Console at http://localhost:9001 (log in with `minioadmin` and your configured password) to inspect the storage bucket.
+You can also browse the MinIO Console at http://localhost:9001 (log in with your configured `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`) to inspect the storage bucket.
 
 > **Note:** MinIO with default credentials is suitable for development and testing only. For production deployments, configure MinIO with proper credentials and TLS, or use a cloud-native storage service.
 

--- a/examples/generic/docker-compose/minio/README.md
+++ b/examples/generic/docker-compose/minio/README.md
@@ -22,6 +22,8 @@ Edit `.env` and set:
 - `BACKEND_SERVICE_URL` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
 - `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` — credentials for MinIO.
 
+Optionally set `AGENT_IMAGE_TAG` to pin the agent image to a specific version (e.g. `0.0.8-generic`). If unset, defaults to `latest-generic`.
+
 Docker Compose automatically reads `.env` when you start the stack.
 
 ### 2. Create the token file

--- a/examples/generic/docker-compose/minio/docker-compose.yml
+++ b/examples/generic/docker-compose/minio/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL}
+      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL:?BACKEND_SERVICE_URL must be set in .env}
       - MCD_AGENT_WRAPPER_TYPE=DOCKER
       - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
       - MCD_STORAGE=S3_COMPATIBLE
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
-      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER}
-      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
@@ -29,8 +29,12 @@ services:
       minio:
         condition: service_healthy
     environment:
-      - MC_HOST_local=http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@minio:9000
-    entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
+      - MC_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MC_PASS=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
+    entrypoint:
+      - sh
+      - -c
+      - mc alias set local http://minio:9000 "$$MC_USER" "$$MC_PASS" && mc mb local/mcd-agent-storage --ignore-existing
 
   minio:
     image: quay.io/minio/minio:latest
@@ -39,8 +43,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
-      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
     volumes:
       - minio-data:/data
     healthcheck:

--- a/examples/generic/docker-compose/minio/docker-compose.yml
+++ b/examples/generic/docker-compose/minio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mcd-agent:
-    image: montecarlodata/agent:latest-generic
+    image: montecarlodata/agent:${AGENT_IMAGE_TAG:-latest-generic}
     ports:
       - "8080:8080"
     environment:

--- a/examples/generic/docker-compose/minio/docker-compose.yml
+++ b/examples/generic/docker-compose/minio/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-      - BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL}
       - MCD_AGENT_WRAPPER_TYPE=DOCKER
       - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
       - MCD_STORAGE=S3_COMPATIBLE
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
-      - MCD_STORAGE_ACCESS_KEY=minioadmin
-      - MCD_STORAGE_SECRET_KEY=change-me-to-a-secure-password
+      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER}
+      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD}
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
@@ -29,7 +29,7 @@ services:
       minio:
         condition: service_healthy
     environment:
-      - MC_HOST_local=http://minioadmin:change-me-to-a-secure-password@minio:9000
+      - MC_HOST_local=http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@minio:9000
     entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
 
   minio:
@@ -39,8 +39,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=change-me-to-a-secure-password
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
     volumes:
       - minio-data:/data
     healthcheck:

--- a/examples/generic/docker-compose/proxy/.env.example
+++ b/examples/generic/docker-compose/proxy/.env.example
@@ -1,0 +1,3 @@
+BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=change-me-to-a-secure-password

--- a/examples/generic/docker-compose/proxy/.env.example
+++ b/examples/generic/docker-compose/proxy/.env.example
@@ -1,5 +1,5 @@
-# Optional: override the agent image tag (defaults to latest-generic)
-# AGENT_IMAGE_TAG=latest-generic
+# Optional: pin the agent image to a specific version (defaults to latest-generic)
+# AGENT_IMAGE_TAG=0.0.8-generic
 
 BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
 MINIO_ROOT_USER=minioadmin

--- a/examples/generic/docker-compose/proxy/.env.example
+++ b/examples/generic/docker-compose/proxy/.env.example
@@ -1,3 +1,6 @@
+# Optional: override the agent image tag (defaults to latest-generic)
+# AGENT_IMAGE_TAG=latest-generic
+
 BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=change-me-to-a-secure-password

--- a/examples/generic/docker-compose/proxy/.gitignore
+++ b/examples/generic/docker-compose/proxy/.gitignore
@@ -1,3 +1,4 @@
+.env
 secrets/*
 !secrets/*.example
 !secrets/integrations/

--- a/examples/generic/docker-compose/proxy/README.md
+++ b/examples/generic/docker-compose/proxy/README.md
@@ -22,6 +22,8 @@ Edit `.env` and set:
 - `BACKEND_SERVICE_URL` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
 - `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` — credentials for MinIO.
 
+Optionally set `AGENT_IMAGE_TAG` to pin the agent image to a specific version (e.g. `0.0.8-generic`). If unset, defaults to `latest-generic`.
+
 Docker Compose automatically reads `.env` when you start the stack.
 
 ### 2. Create the token file

--- a/examples/generic/docker-compose/proxy/README.md
+++ b/examples/generic/docker-compose/proxy/README.md
@@ -11,10 +11,18 @@ Route Monte Carlo Generic Agent traffic through a [Squid](http://www.squid-cache
 
 ### 1. Configure
 
-Edit `docker-compose.yml` and replace:
+Copy the example environment file and fill in your values:
 
-- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
-- `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set:
+
+- `BACKEND_SERVICE_URL` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
+- `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` — credentials for MinIO.
+
+Docker Compose automatically reads `.env` when you start the stack.
 
 ### 2. Create the token file
 

--- a/examples/generic/docker-compose/proxy/docker-compose.yml
+++ b/examples/generic/docker-compose/proxy/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL}
+      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL:?BACKEND_SERVICE_URL must be set in .env}
       - MCD_AGENT_WRAPPER_TYPE=DOCKER
       - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
       - MCD_STORAGE=S3_COMPATIBLE
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
-      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER}
-      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
@@ -42,8 +42,12 @@ services:
       minio:
         condition: service_healthy
     environment:
-      - MC_HOST_local=http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@minio:9000
-    entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
+      - MC_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MC_PASS=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
+    entrypoint:
+      - sh
+      - -c
+      - mc alias set local http://minio:9000 "$$MC_USER" "$$MC_PASS" && mc mb local/mcd-agent-storage --ignore-existing
 
   minio:
     image: quay.io/minio/minio:latest
@@ -52,8 +56,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
-      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
     volumes:
       - minio-data:/data
     healthcheck:

--- a/examples/generic/docker-compose/proxy/docker-compose.yml
+++ b/examples/generic/docker-compose/proxy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mcd-agent:
-    image: montecarlodata/agent:latest-generic
+    image: montecarlodata/agent:${AGENT_IMAGE_TAG:-latest-generic}
     ports:
       - "8080:8080"
     environment:

--- a/examples/generic/docker-compose/proxy/docker-compose.yml
+++ b/examples/generic/docker-compose/proxy/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-      - BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL}
       - MCD_AGENT_WRAPPER_TYPE=DOCKER
       - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
       - MCD_STORAGE=S3_COMPATIBLE
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
-      - MCD_STORAGE_ACCESS_KEY=minioadmin
-      - MCD_STORAGE_SECRET_KEY=change-me-to-a-secure-password
+      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER}
+      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD}
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
@@ -42,7 +42,7 @@ services:
       minio:
         condition: service_healthy
     environment:
-      - MC_HOST_local=http://minioadmin:change-me-to-a-secure-password@minio:9000
+      - MC_HOST_local=http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@minio:9000
     entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
 
   minio:
@@ -52,8 +52,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=change-me-to-a-secure-password
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
     volumes:
       - minio-data:/data
     healthcheck:

--- a/examples/generic/docker-compose/tls-inspection/.env.example
+++ b/examples/generic/docker-compose/tls-inspection/.env.example
@@ -1,5 +1,5 @@
-# Optional: override the agent image tag (defaults to latest-generic)
-# AGENT_IMAGE_TAG=latest-generic
+# Optional: pin the agent image to a specific version (defaults to latest-generic)
+# AGENT_IMAGE_TAG=0.0.8-generic
 
 BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
 MINIO_ROOT_USER=minioadmin

--- a/examples/generic/docker-compose/tls-inspection/.env.example
+++ b/examples/generic/docker-compose/tls-inspection/.env.example
@@ -1,0 +1,4 @@
+BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=change-me-to-a-secure-password
+MITMPROXY_WEB_PASSWORD=change-me-to-a-secure-password

--- a/examples/generic/docker-compose/tls-inspection/.env.example
+++ b/examples/generic/docker-compose/tls-inspection/.env.example
@@ -1,3 +1,6 @@
+# Optional: override the agent image tag (defaults to latest-generic)
+# AGENT_IMAGE_TAG=latest-generic
+
 BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=change-me-to-a-secure-password

--- a/examples/generic/docker-compose/tls-inspection/.gitignore
+++ b/examples/generic/docker-compose/tls-inspection/.gitignore
@@ -1,3 +1,4 @@
+.env
 secrets/*
 !secrets/*.example
 !secrets/integrations/

--- a/examples/generic/docker-compose/tls-inspection/README.md
+++ b/examples/generic/docker-compose/tls-inspection/README.md
@@ -32,6 +32,8 @@ Edit `.env` and set:
 - `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` — credentials for MinIO.
 - `MITMPROXY_WEB_PASSWORD` — password for the mitmproxy web UI.
 
+Optionally set `AGENT_IMAGE_TAG` to pin the agent image to a specific version (e.g. `0.0.8-generic`). If unset, defaults to `latest-generic`.
+
 Docker Compose automatically reads `.env` when you start the stack.
 
 ### 3. Create the token file

--- a/examples/generic/docker-compose/tls-inspection/README.md
+++ b/examples/generic/docker-compose/tls-inspection/README.md
@@ -20,10 +20,19 @@ This creates a CA certificate that mitmproxy uses to intercept TLS connections. 
 
 ### 2. Configure
 
-Edit `docker-compose.yml` and replace:
+Copy the example environment file and fill in your values:
 
-- `<YOUR_BACKEND_SERVICE_URL>` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
-- `change-me-to-a-secure-password` — a secure password for MinIO (appears in 3 places: `mcd-agent`, `create-bucket`, and `minio` services).
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set:
+
+- `BACKEND_SERVICE_URL` — in the Monte Carlo app, go to **Account Information > Agent Service** and copy the **Public endpoint**.
+- `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` — credentials for MinIO.
+- `MITMPROXY_WEB_PASSWORD` — password for the mitmproxy web UI.
+
+Docker Compose automatically reads `.env` when you start the stack.
 
 ### 3. Create the token file
 
@@ -47,7 +56,7 @@ This starts MinIO, creates the storage bucket, launches mitmproxy, and starts th
 
 ### 5. Open the mitmproxy web UI
 
-Open http://localhost:8081 in your browser and log in with password `mitmproxy` (configurable via `web_password` in `docker-compose.yml`). All HTTPS requests from the agent appear in real time. Click any request to inspect:
+Open http://localhost:8081 in your browser and log in with the `MITMPROXY_WEB_PASSWORD` you set in `.env`. All HTTPS requests from the agent appear in real time. Click any request to inspect:
 
 - Full URL and HTTP method
 - Request and response headers

--- a/examples/generic/docker-compose/tls-inspection/docker-compose.yml
+++ b/examples/generic/docker-compose/tls-inspection/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-      - BACKEND_SERVICE_URL=<YOUR_BACKEND_SERVICE_URL>
+      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL}
       - MCD_AGENT_WRAPPER_TYPE=DOCKER
       - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
       - MCD_STORAGE=S3_COMPATIBLE
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
-      - MCD_STORAGE_ACCESS_KEY=minioadmin
-      - MCD_STORAGE_SECRET_KEY=change-me-to-a-secure-password
+      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER}
+      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD}
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
@@ -38,7 +38,7 @@ services:
 
   mitmproxy:
     image: mitmproxy/mitmproxy
-    command: mitmweb --web-host 0.0.0.0 --listen-port 3128 --no-web-open-browser --set web_password=mitmproxy -s /home/mitmproxy/stream_sse.py
+    command: mitmweb --web-host 0.0.0.0 --listen-port 3128 --no-web-open-browser --set web_password=${MITMPROXY_WEB_PASSWORD} -s /home/mitmproxy/stream_sse.py
     ports:
       - "3128:3128"
       - "8081:8081"
@@ -53,7 +53,7 @@ services:
       minio:
         condition: service_healthy
     environment:
-      - MC_HOST_local=http://minioadmin:change-me-to-a-secure-password@minio:9000
+      - MC_HOST_local=http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@minio:9000
     entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
 
   minio:
@@ -63,8 +63,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=change-me-to-a-secure-password
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
     volumes:
       - minio-data:/data
     healthcheck:

--- a/examples/generic/docker-compose/tls-inspection/docker-compose.yml
+++ b/examples/generic/docker-compose/tls-inspection/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mcd-agent:
-    image: montecarlodata/agent:latest-generic
+    image: montecarlodata/agent:${AGENT_IMAGE_TAG:-latest-generic}
     ports:
       - "8080:8080"
     environment:

--- a/examples/generic/docker-compose/tls-inspection/docker-compose.yml
+++ b/examples/generic/docker-compose/tls-inspection/docker-compose.yml
@@ -5,13 +5,13 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
-      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL}
+      - BACKEND_SERVICE_URL=${BACKEND_SERVICE_URL:?BACKEND_SERVICE_URL must be set in .env}
       - MCD_AGENT_WRAPPER_TYPE=DOCKER
       - MCD_STORAGE_BUCKET_NAME=mcd-agent-storage
       - MCD_STORAGE=S3_COMPATIBLE
       - MCD_STORAGE_ENDPOINT_URL=http://minio:9000
-      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER}
-      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - MCD_STORAGE_ACCESS_KEY=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MCD_STORAGE_SECRET_KEY=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
       - MCD_TOKEN_FILE_PATH=/etc/secrets/mcd-agent-token/contents.json
       - MCD_OPS_RUNNER_THREAD_COUNT=18
       - MCD_PUBLISHER_THREAD_COUNT=3
@@ -38,7 +38,7 @@ services:
 
   mitmproxy:
     image: mitmproxy/mitmproxy
-    command: mitmweb --web-host 0.0.0.0 --listen-port 3128 --no-web-open-browser --set web_password=${MITMPROXY_WEB_PASSWORD} -s /home/mitmproxy/stream_sse.py
+    command: mitmweb --web-host 0.0.0.0 --listen-port 3128 --no-web-open-browser --set web_password=${MITMPROXY_WEB_PASSWORD:?MITMPROXY_WEB_PASSWORD must be set in .env} -s /home/mitmproxy/stream_sse.py
     ports:
       - "3128:3128"
       - "8081:8081"
@@ -53,8 +53,12 @@ services:
       minio:
         condition: service_healthy
     environment:
-      - MC_HOST_local=http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@minio:9000
-    entrypoint: ["mc", "mb", "local/mcd-agent-storage", "--ignore-existing"]
+      - MC_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MC_PASS=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
+    entrypoint:
+      - sh
+      - -c
+      - mc alias set local http://minio:9000 "$$MC_USER" "$$MC_PASS" && mc mb local/mcd-agent-storage --ignore-existing
 
   minio:
     image: quay.io/minio/minio:latest
@@ -63,8 +67,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
-      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set in .env}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env}
     volumes:
       - minio-data:/data
     healthcheck:


### PR DESCRIPTION
## Summary

Move environment-specific values (backend URL, MinIO credentials, mitmproxy web password, agent image tag) out of each `docker-compose.yml` and into a per-example `.env` file. Docker Compose reads `.env` automatically, so users copy `.env.example` to `.env`, fill in values, and start — no more editing `docker-compose.yml`.

### Benefits

- `docker-compose.yml` stays pristine — no placeholders to replace, no risk of accidentally committing local edits.
- MinIO password defined once (was duplicated in 3 services per file).
- Easier upgrades — `git pull` changes without local merge conflicts.
- Cleaner README — "copy `.env.example` to `.env`" instead of "edit these placeholders in 3 places".
- Agent image tag is pinnable to a specific version (e.g. `AGENT_IMAGE_TAG=0.0.8-generic`) without editing `docker-compose.yml`.

### Scope

Applied consistently across all three Docker Compose examples:

- `minio/` — `BACKEND_SERVICE_URL`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, optional `AGENT_IMAGE_TAG`
- `proxy/` — same as above
- `tls-inspection/` — same as above plus `MITMPROXY_WEB_PASSWORD`

## Test plan

- [x] `minio` example — agent connected, full storage lifecycle (is_bucket_private, write, read, delete) exercised from Monte Carlo with 200 responses
- [x] `proxy` example — agent routed through Squid, storage lifecycle completed with 200s, CONNECT tunnels visible in Squid access log
- [x] `tls-inspection` example — agent routed through mitmproxy with TLS interception, storage lifecycle completed with 200s, traffic visible in mitmproxy UI; also validated `AGENT_IMAGE_TAG=0.0.8-generic` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)