### PR TITLE
Add Salesforce Data 360 DLO→DMO lineage push example

### DIFF
--- a/examples/push-ingestion/salesforce-data-cloud/.env.example
+++ b/examples/push-ingestion/salesforce-data-cloud/.env.example
@@ -1,0 +1,84 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Data 360 DLO→DMO Lineage Push — Environment Variables
+#
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# Never commit .env to source control — it is already listed in .gitignore.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ── Salesforce credentials ────────────────────────────────────────────────────
+
+# Your org's My Domain URL. Must start with https://.
+# Find it in Salesforce Setup → My Domain.
+# Example: https://mycompany.my.salesforce.com
+SF_ORG_URL=
+
+# Connected app consumer key and secret.
+# In Salesforce Setup → App Manager → your app → View → Consumer Key / Secret.
+# The connected app must have "Enable Client Credentials Flow" checked.
+SF_CLIENT_ID=
+SF_CLIENT_SECRET=
+
+
+# ── Monte Carlo — Ingestion key ───────────────────────────────────────────────
+# Used to push lineage via the Ingest API (/ingest/v1/lineage).
+#
+# Create with the Monte Carlo CLI:
+#   montecarlo integrations create-key --scope Ingestion --description "Data 360 lineage push"
+#
+MCD_INGEST_ID=
+MCD_INGEST_TOKEN=
+
+
+# ── Monte Carlo — Personal API key ───────────────────────────────────────────
+# Used for catalog validation via the GraphQL API.
+# This is a DIFFERENT key from the Ingestion key above.
+#
+# Create in the Monte Carlo UI: Settings → API Keys → Create Key.
+# The key type must be "Personal" (not "Service" or "Ingestion").
+#
+MCD_ID=
+MCD_TOKEN=
+
+
+# ── Monte Carlo — Data Cloud warehouse UUID ───────────────────────────────────
+# The UUID of your Salesforce Data Cloud warehouse in Monte Carlo.
+# Find it in Monte Carlo UI: Settings → Integrations → your Data Cloud connection.
+#
+MCD_RESOURCE_UUID=
+
+
+# ── Optional: logging ─────────────────────────────────────────────────────────
+
+# Log verbosity. Options: DEBUG, INFO, WARNING, ERROR. Default: INFO.
+# Use DEBUG to see every HTTP request and poll attempt when troubleshooting.
+# LOG_LEVEL=INFO
+
+# Log format. Set to "json" for structured output (Splunk, Datadog, CloudWatch, etc.).
+# Default: plain text to stderr.
+# LOG_FORMAT=json
+
+
+# ── Optional: tuning ──────────────────────────────────────────────────────────
+
+# Number of lineage edges per Monte Carlo push batch. Default: 500.
+# Reduce if you hit request size limits.
+# INGEST_BATCH_SIZE=500
+
+# Maximum number of SOAP polling attempts when retrieving Salesforce metadata.
+# Default: 120. Each poll waits METADATA_POLL_INTERVAL seconds, so the default
+# timeout is 120 × 5 = 600 seconds (10 minutes). Increase for very large orgs.
+# If the script times out at Step 3, double METADATA_MAX_POLLS and retry.
+# METADATA_MAX_POLLS=120
+
+# Seconds between SOAP polls. Default: 5.
+# METADATA_POLL_INTERVAL=5
+
+
+# ── Optional: data space fallback ─────────────────────────────────────────────
+# Used when a DLO record's data space cannot be resolved from the XML metadata
+# or the data-streams API. Default: "default".
+# Set this if your org uses a different primary data space name.
+# SF_DEFAULT_DATA_SPACE=default

--- a/examples/push-ingestion/salesforce-data-cloud/.gitignore
+++ b/examples/push-ingestion/salesforce-data-cloud/.gitignore
@@ -1,0 +1,66 @@
+# This file is used for Git repositories to specify intentionally untracked files that Git should ignore. 
+# If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
+# For useful gitignore templates see: https://github.com/github/gitignore
+
+# Salesforce cache
+.sf/
+.sfdx/
+.localdevserver/
+deploy-options.json
+
+# LWC VSCode autocomplete
+**/lwc/jsconfig.json
+
+# LWC Jest coverage reports
+coverage/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+# ApexPMD cache
+.pmdCache
+
+# Eslint cache
+.eslintcache
+
+# MacOS system files
+.DS_Store
+
+# Windows system files
+Thumbs.db
+ehthumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/
+
+# Local environment variables
+.env
+
+# Failed-edge retry files from push_lineage.py
+failed_edges_*.json
+
+# Python Salesforce Functions
+**/__pycache__/
+**/.venv/
+**/venv/
+
+# SFDX project scaffolding (not part of the Python PoC)
+force-app/
+config/
+scripts/
+.husky/
+.vscode/
+.prettierignore
+.prettierrc
+.forceignore
+eslint.config.js
+jest.config.js
+package.json
+package-lock.json
+sfdx-project.json

--- a/examples/push-ingestion/salesforce-data-cloud/README.md
+++ b/examples/push-ingestion/salesforce-data-cloud/README.md
@@ -225,7 +225,8 @@ LOG_FORMAT=json python3 push_lineage.py 2>> /var/log/data360-lineage.jsonl
 | `LOG_LEVEL` | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `LOG_FORMAT` | plain | Set to `json` for structured log output |
 | `INGEST_BATCH_SIZE` | `500` | Edges per Monte Carlo push batch |
-| `METADATA_MAX_POLLS` | `120` | Max SOAP polling attempts before timeout |
+| `METADATA_BATCH_SIZE` | `10` | ObjectSourceTargetMap records per retrieve batch (smaller = faster per-batch, more API calls) |
+| `METADATA_MAX_POLLS` | `120` | Max SOAP polling attempts per retrieve batch |
 | `METADATA_POLL_INTERVAL` | `5` | Seconds between SOAP polls |
 | `SF_DEFAULT_DATA_SPACE` | `default` | Fallback data space when XML has no `<dataSpace>` and the org has multiple data spaces |
 

--- a/examples/push-ingestion/salesforce-data-cloud/README.md
+++ b/examples/push-ingestion/salesforce-data-cloud/README.md
@@ -1,0 +1,294 @@
+# Data 360 DLO→DMO Lineage Push
+
+Pushes Salesforce Data 360 DLO→DMO lineage into Monte Carlo so your data transformation
+pipeline appears as observable, trusted lineage inside Monte Carlo's data catalog —
+the observability layer for your Agentforce data.
+
+This is a standalone Python script. It has no external service dependencies beyond
+Salesforce and Monte Carlo. Run it on any machine that can reach both APIs, or schedule
+it as a cron job.
+
+---
+
+## What It Does
+
+The script runs a five-step pipeline:
+
+1. **Authenticate with Salesforce** — client-credentials OAuth flow using your connected
+   app credentials. A single token covers all data spaces (no per-dataspace credentials needed).
+2. **Fetch Data Spaces** — enumerates your Data 360 data spaces so lineage is attributed
+   to the correct schema partition.
+3. **Retrieve ObjectSourceTargetMap metadata** — calls the Salesforce SOAP Metadata API
+   to get every DLO→DMO mapping defined in your org.
+4. **Parse DLO→DMO edges** — extracts source/target pairs and preliminary data space from
+   the XML metadata.
+4b. **Validate catalog coverage** — bulk-fetches all tables for the warehouse from Monte
+    Carlo's catalog in one paginated query (scoped to your Data Cloud warehouse UUID to
+    prevent cross-org contamination), then validates each DLO and DMO against that result
+    locally. Edges for uncatalogued tables are skipped and logged, so you can see exactly
+    what's missing and re-run once the connector syncs.
+5. **Push lineage to Monte Carlo** — sends validated edges to Monte Carlo's Ingest API in
+   batches with automatic retry. Failed batches are saved to a local JSON file for retry.
+
+Lineage pushed: all DLO→DMO mappings configured in the org (e.g. `Account__dll` → `Account__dlm`).
+
+---
+
+## Prerequisites
+
+- Python 3.9 or later
+- Network access to your Salesforce org and `https://api.getmontecarlo.com`
+- A Salesforce **Connected App** with client credentials flow enabled
+- Two Monte Carlo API keys (see [Configuration](#configuration) below)
+- The **Monte Carlo Data Cloud connector** must have completed at least one metadata scan
+  so that DLO and DMO tables appear in the catalog (required for Step 4b validation)
+- The `montecarlo` CLI installed and authenticated (for creating Ingestion keys):
+  `pip install montecarlo-cli` then `montecarlo auth login`
+
+---
+
+## Installation
+
+```bash
+# Copy this directory to your machine, then:
+cd salesforce-data-cloud
+
+python3 -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+
+pip install -r requirements.txt
+```
+
+---
+
+## Configuration
+
+Copy the example file and fill in your credentials:
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` in a text editor. Every variable is documented with inline comments.
+
+### Monte Carlo API keys
+
+You need **two** Monte Carlo keys with different scopes:
+
+**Key 1 — Ingestion key** (pushes lineage to Monte Carlo)
+
+```bash
+montecarlo integrations create-key \
+  --scope Ingestion \
+  --description "Data 360 lineage push"
+```
+
+Copy the printed `key_id` → `MCD_INGEST_ID` and `key_secret` → `MCD_INGEST_TOKEN`.
+
+**Key 2 — Personal API key** (catalog validation via GraphQL)
+
+Create one in the Monte Carlo UI: **Settings → API Keys → Create Key**.
+Copy both values into `MCD_ID` and `MCD_TOKEN`.
+
+> These are two different keys with different scopes. Mixing them up is the most
+> common cause of authentication errors. See [Troubleshooting](TROUBLESHOOTING.md).
+
+### Monte Carlo warehouse UUID
+
+Set `MCD_RESOURCE_UUID` to your Salesforce Data Cloud warehouse UUID.
+Find it in the Monte Carlo UI: **Settings → Integrations → your Data Cloud connection**.
+
+### Salesforce Connected App
+
+The script uses the **client credentials** OAuth flow. Your connected app must:
+
+- Have **"Enable Client Credentials Flow"** checked under OAuth settings
+- Have API access and permission to retrieve `ObjectSourceTargetMap` metadata
+- Be assigned to a run-as user with Metadata API access
+
+Set `SF_ORG_URL` to your org's **My Domain URL**
+(e.g. `https://mycompany.my.salesforce.com`), not `login.salesforce.com`.
+
+---
+
+## Salesforce-only Diagnostic
+
+Before running the full script, you can validate Salesforce connectivity independently
+(no Monte Carlo credentials needed):
+
+```bash
+python3 sf_diagnostic.py
+```
+
+This tests OAuth auth, the Dataspace SOQL query, the SOAP Metadata API retrieve, and
+parses the resulting XML — printing timing, edge count, and data space information.
+Useful for handing to a Salesforce admin to confirm API access before involving MC credentials.
+
+---
+
+## Usage
+
+### Step 1 — Dry run (always do this first)
+
+```bash
+python3 push_lineage.py --dry-run
+```
+
+This runs every step — authenticates, retrieves metadata, resolves data spaces, validates
+catalog coverage — but skips the final push to Monte Carlo. You will see every edge that
+*would* be pushed, along with the target Monte Carlo warehouse UUID. Use this to validate all
+credentials and confirm the expected edges are found before committing anything.
+
+Example output:
+
+```
+[10:42:01] [INFO   ] [run=a1b2c3d4] === Data 360 Lineage Push | run_id=a1b2c3d4 [DRY RUN] ===
+[10:42:03] [INFO   ] [run=a1b2c3d4] Step 1: Authenticating with Salesforce (...)
+[10:42:03] [INFO   ] [run=a1b2c3d4]   Authenticated (0.8s)
+[10:42:04] [INFO   ] [run=a1b2c3d4] Step 2: Fetching Salesforce data spaces
+[10:42:04] [INFO   ] [run=a1b2c3d4]   Found 1 data space(s): ['default']
+[10:42:04] [INFO   ] [run=a1b2c3d4] Step 3: Retrieving ObjectSourceTargetMap metadata
+[10:42:04] [INFO   ] [run=a1b2c3d4]   Retrieve job started
+[10:42:08] [INFO   ] [run=a1b2c3d4]   Waiting for Salesforce metadata retrieve... poll 1/120
+[10:42:15] [INFO   ] [run=a1b2c3d4]   Retrieved after 3 poll(s) (11.2s)
+[10:42:15] [INFO   ] [run=a1b2c3d4] Step 4: Parsing DLO->DMO edges from metadata
+[10:42:15] [INFO   ] [run=a1b2c3d4]   Found 26 ObjectSourceTargetMap record(s)
+[10:42:15] [INFO   ] [run=a1b2c3d4]   20 DLO->DMO edge(s) extracted (0.1s)
+[10:42:15] [INFO   ] [run=a1b2c3d4] Step 4b: Validating DLO and DMO tables exist in Monte Carlo catalog
+[10:42:15] [INFO   ] [run=a1b2c3d4]   Catalog fetch page 1: 40 table(s) retrieved so far
+[10:42:28] [INFO   ] [run=a1b2c3d4]   Fetched 40 table(s) from MC catalog (13.1s)
+[10:42:28] [INFO   ] [run=a1b2c3d4]   Catalog check complete: 40 matched, 0 not in catalog (13.1s)
+[10:42:28] [INFO   ] [run=a1b2c3d4]   20 edge(s) ready to push
+[10:42:28] [INFO   ] [run=a1b2c3d4] DLO->DMO edges (20 total):
+[10:42:28] [INFO   ] [run=a1b2c3d4]   [default] Account__dll -> Account__dlm
+[10:42:28] [INFO   ] [run=a1b2c3d4]   [default] Contact__dll -> Contact__dlm
+...
+[10:42:28] [INFO   ] [run=a1b2c3d4] [dry-run] Would push 20 DLO->DMO edge(s) to Monte Carlo
+                                    warehouse UUID=abc123.... Run without --dry-run to commit.
+```
+
+### Step 2 — Live push
+
+```bash
+python3 push_lineage.py
+```
+
+On success the final log line contains:
+- `run_id` — unique identifier for this run (appears in every log line)
+- DLO→DMO edge count
+- `invocation_ids` — Monte Carlo's receipt tokens; keep these if you need to report
+  an issue to Monte Carlo support
+
+---
+
+## Scheduling
+
+Run the script on a schedule to keep lineage current. A daily run is sufficient for
+most orgs; run more frequently if your DLO→DMO mappings change often.
+
+The push is **idempotent** — running it multiple times is safe. Duplicate edges are
+deduplicated by Monte Carlo.
+
+### cron (Linux/macOS)
+
+```cron
+0 6 * * * cd /opt/data360-lineage && .venv/bin/python push_lineage.py >> /var/log/data360-lineage.log 2>&1
+```
+
+### Structured logs for log aggregation (Splunk, Datadog, CloudWatch)
+
+```bash
+LOG_FORMAT=json python3 push_lineage.py 2>> /var/log/data360-lineage.jsonl
+```
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description |
+|---|---|
+| `SF_ORG_URL` | Salesforce org My Domain URL, e.g. `https://mycompany.my.salesforce.com` |
+| `SF_CLIENT_ID` | Connected app consumer key |
+| `SF_CLIENT_SECRET` | Connected app consumer secret |
+| `MCD_INGEST_ID` | Monte Carlo **Ingestion** key ID |
+| `MCD_INGEST_TOKEN` | Monte Carlo **Ingestion** key secret |
+| `MCD_ID` | Monte Carlo **Personal API** key ID |
+| `MCD_TOKEN` | Monte Carlo **Personal API** key secret |
+| `MCD_RESOURCE_UUID` | Monte Carlo Data Cloud warehouse UUID |
+
+### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_LEVEL` | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `LOG_FORMAT` | plain | Set to `json` for structured log output |
+| `INGEST_BATCH_SIZE` | `500` | Edges per Monte Carlo push batch |
+| `METADATA_MAX_POLLS` | `120` | Max SOAP polling attempts before timeout |
+| `METADATA_POLL_INTERVAL` | `5` | Seconds between SOAP polls |
+| `SF_DEFAULT_DATA_SPACE` | `default` | Fallback data space when XML has no `<dataSpace>` and the org has multiple data spaces |
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success, or dry run completed with no errors |
+| `1` | Known error — check the log line immediately above |
+| `2` | Unexpected exception — full traceback is in the log |
+
+---
+
+## Failed-Edge Files
+
+If one or more batches fail during the Monte Carlo push, the script saves the failed
+edges to a JSON file in the same directory as `push_lineage.py`:
+
+```
+failed_edges_dlo_dmo_<run_id>_<timestamp>.json
+```
+
+The file is created with owner-only permissions (mode 0600) and is excluded from
+version control via `.gitignore`. The script exits with code `1` after saving.
+Re-run after resolving the issue — the push is idempotent so duplicate edges are
+safe to re-send.
+
+---
+
+## Troubleshooting
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for solutions to common errors.
+
+For issues that require Monte Carlo support, share your `run_id` (printed at the start
+and end of every run) and the `invocation_ids` from the final log line.
+
+**Monte Carlo contact:** Your Monte Carlo account team
+
+---
+
+## Data Flow
+
+```
+Salesforce Data 360 org
+  └── SOAP Metadata API → ObjectSourceTargetMap → DLO→DMO edges
+
+Monte Carlo GraphQL API
+  └── Catalog validation (DLO and DMO table presence check)
+
+Monte Carlo Ingest API
+  └── Lineage push (batched, idempotent, with automatic retry)
+```
+
+---
+
+## Security Notes
+
+- Credentials are read from `.env` or environment variables — never hardcoded.
+- `.env` is listed in `.gitignore` and must not be committed to source control.
+- The script makes outbound HTTPS calls only. No inbound ports are opened.
+- Salesforce authentication uses client credentials flow — no user session, no browser.
+- `LOG_LEVEL=DEBUG` does not expose credentials in the log output.
+- SOAP XML responses are parsed with `defusedxml` to block entity expansion attacks.
+- `SF_ORG_URL` is validated at startup: must be HTTPS and must not resolve to a private/loopback/reserved IP address (both literal and via DNS resolution).

--- a/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
+++ b/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
@@ -1,0 +1,246 @@
+# Troubleshooting
+
+If you cannot resolve an issue after checking this guide, contact Monte Carlo support
+at your Monte Carlo account team and include:
+- Your `run_id` (printed at the start and end of every run as `[run=XXXXXXXX]`)
+- The full log output from the failing run (use `LOG_LEVEL=DEBUG` for maximum detail)
+- The `invocation_ids` from the final summary line if the run reached the push stage
+
+---
+
+## Quick Diagnostic
+
+Run with full debug logging:
+
+```bash
+LOG_LEVEL=DEBUG python3 push_lineage.py --dry-run
+```
+
+This prints every SOAP poll attempt, every catalog and edge decision, and step-level
+events — without writing anything to Monte Carlo. It is safe to run as many times as needed.
+
+---
+
+## Credential Errors
+
+### `Required environment variable 'SF_ORG_URL' is not set`
+
+A required variable is missing from your `.env` file. Check that:
+- Your `.env` file is in the same directory as `push_lineage.py`
+- The variable name is spelled correctly (all caps, underscores)
+- The value is not empty (no bare `SF_ORG_URL=` with nothing after the `=`)
+
+### `Salesforce auth failed: invalid_client — client identifier invalid`
+
+The `SF_CLIENT_ID` (consumer key) is wrong or the connected app does not exist.
+Re-copy the Consumer Key from Salesforce Setup → App Manager → your app → View.
+
+### `Salesforce auth failed: invalid_client_credentials`
+
+The connected app is not configured for client credentials flow, or the connected
+app's run-as user is not set. In Salesforce Setup → App Manager → your app:
+- Confirm **"Enable Client Credentials Flow"** is checked under OAuth settings
+- Confirm a **Run As** user is assigned and that user has API access
+
+### `Salesforce auth failed: invalid_grant`
+
+The org URL is wrong. `SF_ORG_URL` must be your **My Domain URL**
+(e.g. `https://mycompany.my.salesforce.com`), not `login.salesforce.com`.
+
+### `MC GraphQL error: Unauthorized`
+
+The GraphQL key is wrong or is the wrong key type. There are **two different** Monte
+Carlo keys needed:
+
+| Variable | Key type | How to create |
+|---|---|---|
+| `MCD_INGEST_ID` / `MCD_INGEST_TOKEN` | Ingestion key | `montecarlo integrations create-key --scope Ingestion` |
+| `MCD_ID` / `MCD_TOKEN` | Personal API key | Monte Carlo UI → Settings → API Keys |
+
+Swapping these two will cause 401 errors on one of the two calls. Confirm each key
+is in the correct variable pair.
+
+### `403 from Monte Carlo Ingest API`
+
+Your Ingestion key exists but is not authorized for the target warehouse. This means:
+- The key was created without `--scope Ingestion`, or
+- The warehouse UUID being targeted is not associated with this key
+
+Re-create the key with `montecarlo integrations create-key --scope Ingestion`.
+
+---
+
+## Warehouse UUID
+
+### `Required environment variable 'MCD_RESOURCE_UUID' is not set`
+
+`MCD_RESOURCE_UUID` is required. Find your Data Cloud warehouse UUID in the Monte Carlo
+UI: **Settings → Integrations → your Data Cloud connection**.
+
+---
+
+## Metadata Retrieval Errors
+
+### Script appears to hang after "Step 3: Retrieving ObjectSourceTargetMap metadata"
+
+This is normal. The Salesforce SOAP Metadata API is asynchronous — the script submits
+a retrieve job and polls for completion. With the default settings (120 polls × 5 seconds)
+this can take up to 10 minutes. You will see a progress message every 5 polls:
+
+```
+[10:42:08] [INFO] Waiting for Salesforce metadata retrieve... poll 1/120
+[10:42:33] [INFO] Waiting for Salesforce metadata retrieve... poll 6/120
+```
+
+If you see no progress messages at all, something may have gone wrong silently — run
+with `LOG_LEVEL=DEBUG` to see every poll response.
+
+### `Metadata retrieve did not complete within Xs`
+
+The Salesforce job timed out. The default timeout is 120 polls × 5 seconds = 10 minutes.
+Large orgs with many DLO→DMO mappings may need longer. Options:
+1. Double `METADATA_MAX_POLLS` in `.env` and retry (e.g. `METADATA_MAX_POLLS=240` gives 20 minutes)
+2. Try again — Salesforce metadata retrieval can be slow under org load
+3. Check Salesforce org status at status.salesforce.com
+
+### `Salesforce retrieve job failed [INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY]`
+
+The connected app's run-as user does not have permission to retrieve
+`ObjectSourceTargetMap` metadata. The user needs a profile or permission set that
+includes Metadata API access and Data Cloud administrative permissions.
+
+### `Salesforce SOAP fault [sf:INVALID_SESSION_ID]`
+
+The OAuth token expired during a long metadata poll. This is unusual with client
+credentials (tokens are typically valid for 2 hours) but can occur. Re-run the script
+to get a fresh token.
+
+### `ZIP contained no .objectSourceTargetMap files`
+
+The retrieve succeeded but no `ObjectSourceTargetMap` records exist in the org.
+Possible causes:
+- No DLO→DMO mappings have been defined yet in Data 360
+- The metadata type is not available in this Salesforce edition
+
+Run with `LOG_LEVEL=DEBUG` to see the full list of files returned in the ZIP. If the
+ZIP contains files ending in a different extension, contact Monte Carlo support.
+
+### `DLO->DMO edges (0 total)` after a successful retrieve
+
+The metadata was retrieved but none of the records contained DLO→DMO mappings
+(objects ending in `__dll` → `__dlm`). Confirm that your Data 360 org has DLO→DMO
+transformation mappings configured. If you see records in the XML but they are being
+skipped, run with `LOG_LEVEL=DEBUG` to see per-file parse details.
+
+---
+
+## Catalog Validation Warnings
+
+### `NOT in MC catalog: Account__dll` (or similar table name)
+
+Step 4b checks that each DLO and DMO table exists in Monte Carlo before pushing.
+When a table is missing, its lineage edge is skipped and this warning is logged.
+
+**Common causes:**
+- The Monte Carlo Data Cloud connector has not yet completed its first metadata scan
+- The table was created in Salesforce after the last connector sync
+- The table name in the `ObjectSourceTargetMap` does not match the catalogued name
+
+**What to do:**
+1. In Monte Carlo, go to Settings → Integrations → your Data Cloud connection
+2. Trigger a manual metadata sync if one is available, or wait for the scheduled sync
+3. Re-run this script once the sync completes — the push is idempotent, so edges that
+   were already pushed for other tables are safe to re-send
+
+### `Catalog check complete: X found, Y missing`
+
+If `Y > 0`, some edges will be skipped. The warning above lists the specific table
+names. After the Data Cloud connector syncs those tables into Monte Carlo, re-run the
+script to push their lineage edges.
+
+### `MC GraphQL error` during catalog validation (Step 4b)
+
+The catalog validation step failed before the push could proceed. The script exits
+rather than push blindly. Check:
+- `MCD_ID` / `MCD_TOKEN` are set and are a Personal API key
+- Network connectivity to `https://api.getmontecarlo.com`
+
+Run with `LOG_LEVEL=DEBUG` to see the specific error.
+
+---
+
+## Push Errors
+
+### `failed_edges_*.json` file created
+
+One or more batches failed during the Monte Carlo push. The file contains the raw
+edge objects that were not pushed. The absolute path is printed in the log.
+
+After resolving the underlying error, re-run the full script:
+
+```bash
+python3 push_lineage.py
+```
+
+The push is idempotent — duplicate edges are safe and deduplicated by Monte Carlo.
+
+### `0 edges found — nothing to push`
+
+Either your org has no DLO→DMO mappings configured, or all edges were filtered by
+the catalog validation step (all tables are missing from MC). Run with `--dry-run`
+and `LOG_LEVEL=DEBUG` to trace the full pipeline.
+
+If Step 4b shows many missing tables, the Data Cloud connector has likely not yet
+completed a metadata scan. Trigger a manual sync in Monte Carlo and re-run.
+
+If you see `WARNING: Could not resolve data space` in the log, set
+`SF_DEFAULT_DATA_SPACE` to your org's primary data space name.
+
+---
+
+## Data Space Issues
+
+### `Data space mismatch: Account__dll is in 'default' but Account__dlm is in 'other'`
+
+Step 4b found the DLO and DMO in the MC catalog, but in **different data spaces**. The
+script skips these edges rather than push lineage to the wrong place.
+
+This usually means:
+- The tables were recently moved between data spaces and the MC connector has a stale entry
+- The DLO and DMO belong to different orgs or data spaces by design
+
+**What to do:**
+1. In Monte Carlo, confirm which data space each table is catalogued under
+2. Trigger a manual metadata sync (Settings → Integrations → your Data Cloud connection)
+3. Re-run once the sync completes — mismatched edges will be pushed once both sides agree
+
+---
+
+### Lineage appears in Monte Carlo but under the wrong schema / data space
+
+The data space assigned to an edge in Monte Carlo comes from (in priority order):
+1. The MC catalog's `dataset` field (authoritative — set during Step 4b validation)
+2. The `<dataSpace>` field in the `ObjectSourceTargetMap` XML
+3. The `SF_DEFAULT_DATA_SPACE` env var (default: `"default"`)
+
+If edges are landing under the wrong data space after validation, check that the
+tables are catalogued correctly in Monte Carlo (Settings → Integrations → your Data
+Cloud connection). Run with `LOG_LEVEL=DEBUG` to see the data space assigned to each
+edge.
+
+---
+
+## Common Setup Checklist
+
+If you're unsure where a problem is, work through this list:
+
+- [ ] Python 3.9+ installed (`python3 --version`)
+- [ ] Dependencies installed (`pip install -r requirements.txt`)
+- [ ] `.env` file exists in the same directory as `push_lineage.py`
+- [ ] `SF_ORG_URL` starts with `https://` and is the My Domain URL (not `login.salesforce.com`)
+- [ ] Connected app has "Enable Client Credentials Flow" enabled
+- [ ] `MCD_INGEST_ID`/`MCD_INGEST_TOKEN` are the **Ingestion** key (not the Personal key)
+- [ ] `MCD_ID`/`MCD_TOKEN` are the **Personal API** key (not the Ingestion key)
+- [ ] `MCD_RESOURCE_UUID` is set to the Data Cloud warehouse UUID from Monte Carlo UI
+- [ ] `--dry-run` completes successfully before attempting a live push
+- [ ] Monte Carlo Data Cloud connector has completed at least one metadata scan (required for catalog validation)

--- a/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
+++ b/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
@@ -83,25 +83,28 @@ UI: **Settings → Integrations → your Data Cloud connection**.
 
 ### Script appears to hang after "Step 3: Retrieving ObjectSourceTargetMap metadata"
 
-This is normal. The Salesforce SOAP Metadata API is asynchronous — the script submits
-a retrieve job and polls for completion. With the default settings (120 polls × 5 seconds)
-this can take up to 10 minutes. You will see a progress message every 5 polls:
+This is normal. The script first calls `listMetadata` to enumerate all records (~0.5s),
+then retrieves them in batches of 10 (configurable via `METADATA_BATCH_SIZE`). Each batch
+is an asynchronous SOAP job that typically completes in 5–10 seconds. Progress is logged
+after every batch with a rolling ETA:
 
 ```
-[10:42:08] [INFO] Waiting for Salesforce metadata retrieve... poll 1/120
-[10:42:33] [INFO] Waiting for Salesforce metadata retrieve... poll 6/120
+[10:42:04] [INFO] Found 27 ObjectSourceTargetMap record(s) — retrieving in 3 batch(es) of up to 10
+[10:42:11] [INFO] Batch 1/3 complete (10 record(s), 6.5s) — est. 13s remaining
+[10:42:17] [INFO] Batch 2/3 complete (10 record(s), 6.5s) — est. 6s remaining
+[10:42:23] [INFO] Batch 3/3 complete (7 record(s), 6.4s)
 ```
 
-If you see no progress messages at all, something may have gone wrong silently — run
-with `LOG_LEVEL=DEBUG` to see every poll response.
+If you see no progress messages at all, run with `LOG_LEVEL=DEBUG` to see each poll attempt.
 
-### `Metadata retrieve did not complete within Xs`
+### `Batch retrieve did not complete within Xs`
 
-The Salesforce job timed out. The default timeout is 120 polls × 5 seconds = 10 minutes.
-Large orgs with many DLO→DMO mappings may need longer. Options:
-1. Double `METADATA_MAX_POLLS` in `.env` and retry (e.g. `METADATA_MAX_POLLS=240` gives 20 minutes)
-2. Try again — Salesforce metadata retrieval can be slow under org load
-3. Check Salesforce org status at status.salesforce.com
+A single batch timed out. The default per-batch timeout is 120 polls × 5 seconds = 10 minutes,
+which should be sufficient for any batch size. Options:
+1. Reduce `METADATA_BATCH_SIZE` (e.g. `METADATA_BATCH_SIZE=5`) so each batch is smaller
+2. Increase `METADATA_MAX_POLLS` if the org is under heavy load
+3. Try again — Salesforce metadata retrieval can be slow under org load
+4. Check Salesforce org status at status.salesforce.com
 
 ### `Salesforce retrieve job failed [INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY]`
 

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -1,0 +1,1024 @@
+#!/usr/bin/env python3
+"""
+Data 360 DLO->DMO Lineage Push (Pandora Push Model)
+
+Pipeline:
+  1. Authenticate with Salesforce via OAuth client credentials
+  2. Fetch Salesforce data spaces (for data-space resolution fallback)
+  3. Retrieve ObjectSourceTargetMap metadata via SOAP Metadata API
+  4. Parse DLO->DMO edges; assign preliminary data space from XML field or fallback
+  4b. Validate tables exist in MC catalog; overwrite data space with authoritative
+      value from MC catalog dataset field
+  5. Push DLO->DMO lineage to Monte Carlo via pycarlo IngestionService
+
+Usage:
+  python3 push_lineage.py --dry-run
+  python3 push_lineage.py
+
+Required env vars (see .env.example):
+  SF_ORG_URL, SF_CLIENT_ID, SF_CLIENT_SECRET
+  MCD_INGEST_ID, MCD_INGEST_TOKEN   — Ingestion key (push lineage)
+  MCD_ID, MCD_TOKEN                 — Personal API key (catalog validation)
+  MCD_RESOURCE_UUID                 — Monte Carlo Data Cloud warehouse UUID
+
+Optional env vars:
+  LOG_LEVEL              — DEBUG/INFO/WARNING/ERROR (default: INFO)
+  LOG_FORMAT             — json for structured output (default: plain)
+  INGEST_BATCH_SIZE      — edges per push batch (default: 500)
+  METADATA_MAX_POLLS     — max SOAP polling attempts (default: 120)
+  METADATA_POLL_INTERVAL — seconds between SOAP polls (default: 5)
+  SF_DEFAULT_DATA_SPACE  — fallback data space name (default: default)
+"""
+import argparse
+import base64
+import io
+import ipaddress
+import json
+import logging
+import os
+import signal
+import socket
+import sys
+import time
+import uuid
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+from xml.sax.saxutils import escape
+
+import requests
+from dotenv import load_dotenv
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+try:
+    import defusedxml.ElementTree as SafeET
+except ImportError as err:
+    sys.exit(
+        f"ERROR: defusedxml is not installed. Run: pip install defusedxml>=0.7.1\n  ({err})"
+    )
+
+try:
+    from pycarlo.core import Client, Session
+    from pycarlo.features.ingestion import IngestionService
+    from pycarlo.features.ingestion.models import LineageAssetRef, LineageEvent
+except ImportError as err:
+    sys.exit(
+        f"ERROR: pycarlo is not installed. Run: pip install pycarlo>=0.12.251\n  ({err})"
+    )
+
+load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+SF_API_VERSION = "62.0"
+DB = "salesforce-data-cloud"
+DC_RESOURCE_TYPE = "salesforce-data-cloud"
+MC_GRAPHQL_URL = "https://api.getmontecarlo.com/graphql"
+MC_INGEST_URL = "https://integrations.getmontecarlo.com"
+
+
+def _parse_positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    try:
+        val = int(raw)
+        if val < 1:
+            raise ValueError("must be >= 1")
+        return val
+    except ValueError as exc:
+        sys.exit(f"Invalid {name}={raw!r}: {exc}")
+
+
+def _parse_positive_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, str(default))
+    try:
+        val = float(raw)
+        if val <= 0:
+            raise ValueError("must be > 0")
+        return val
+    except ValueError as exc:
+        sys.exit(f"Invalid {name}={raw!r}: {exc}")
+
+
+INGEST_BATCH_SIZE      = _parse_positive_int("INGEST_BATCH_SIZE", 500)
+METADATA_MAX_POLLS     = _parse_positive_int("METADATA_MAX_POLLS", 120)
+METADATA_POLL_INTERVAL = _parse_positive_float("METADATA_POLL_INTERVAL", 5.0)
+
+ZIP_MAX_FILES = 10_000
+ZIP_MAX_BYTES = 500 * 1024 * 1024  # 500 MB
+
+OSTM_NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+SOAP_NS = {
+    "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
+    "met":     "http://soap.sforce.com/2006/04/metadata",
+}
+
+# ── SOAP envelope templates ───────────────────────────────────────────────────
+_RETRIEVE_ENVELOPE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:met="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Header>
+    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
+  </soapenv:Header>
+  <soapenv:Body>
+    <met:retrieve>
+      <met:retrieveRequest>
+        <met:apiVersion>{api_version}</met:apiVersion>
+        <met:unpackaged>
+          <met:types>
+            <met:members>*</met:members>
+            <met:name>ObjectSourceTargetMap</met:name>
+          </met:types>
+        </met:unpackaged>
+      </met:retrieveRequest>
+    </met:retrieve>
+  </soapenv:Body>
+</soapenv:Envelope>"""
+
+_STATUS_ENVELOPE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:met="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Header>
+    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
+  </soapenv:Header>
+  <soapenv:Body>
+    <met:checkRetrieveStatus>
+      <met:asyncProcessId>{async_id}</met:asyncProcessId>
+      <met:includeZip>true</met:includeZip>
+    </met:checkRetrieveStatus>
+  </soapenv:Body>
+</soapenv:Envelope>"""
+
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        data: dict = {
+            "ts":     datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level":  record.levelname,
+            "run_id": getattr(record, "run_id", ""),
+            "msg":    record.getMessage(),
+        }
+        if record.exc_info:
+            data["exc"] = self.formatException(record.exc_info)
+        return json.dumps(data)
+
+
+class _RunIdFilter(logging.Filter):
+    def __init__(self, run_id: str) -> None:
+        super().__init__()
+        self.run_id = run_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.run_id = self.run_id  # type: ignore[attr-defined]
+        return True
+
+
+def _setup_logging(run_id: str) -> logging.Logger:
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    _valid_levels = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+    if level_name not in _valid_levels:
+        print(
+            f"WARNING: Unknown LOG_LEVEL={level_name!r}, using INFO. "
+            f"Valid values: {', '.join(_valid_levels)}",
+            file=sys.stderr,
+        )
+        level_name = "INFO"
+    level = getattr(logging, level_name, logging.INFO)
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.addFilter(_RunIdFilter(run_id))
+
+    if os.environ.get("LOG_FORMAT", "").lower() == "json":
+        handler.setFormatter(_JsonFormatter())
+    else:
+        fmt = "[%(asctime)s] [%(levelname)-7s] [run=%(run_id)s] %(message)s"
+        handler.setFormatter(logging.Formatter(fmt, datefmt="%H:%M:%S"))
+
+    logger = logging.getLogger("push_lineage")
+    logger.setLevel(level)
+    logger.handlers = [handler]
+    logger.propagate = False
+    return logger
+
+
+# Module-level placeholder — replaced in main() before any function is called
+log: logging.Logger = logging.getLogger("push_lineage")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+def _require(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        log.error(
+            "Required environment variable '%s' is not set. "
+            "Set it in your .env file (see .env.example for the expected format).",
+            name,
+        )
+        sys.exit(1)
+    return val
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Suppress retry for 4xx HTTP errors — they won't resolve on retry."""
+    resp = getattr(exc, "response", None)
+    if resp is not None and 400 <= resp.status_code < 500:
+        return False
+    return True
+
+
+_retrying = retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=2, min=2, max=60),
+    retry=retry_if_exception(_is_retryable),
+    reraise=True,
+)
+
+
+def _save_failed_edges(run_id: str, kind: str, edges: list) -> str:
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = Path(__file__).parent / f"failed_edges_{kind}_{run_id}_{ts}.json"
+    content = json.dumps(edges, indent=2).encode()
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, content)
+    except BaseException:
+        os.close(fd)
+        path.unlink(missing_ok=True)
+        raise
+    else:
+        os.close(fd)
+    log.info("  Failed edges saved to: %s", path.resolve())
+    return str(path)
+
+
+# ── Salesforce service ────────────────────────────────────────────────────────
+class SalesforceDataCloudService:
+    """Encapsulates Salesforce authentication and metadata retrieval."""
+
+    def __init__(self, instance_url: str, client_id: str, client_secret: str) -> None:
+        self.instance_url = instance_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._token: str = ""
+
+    @property
+    def token(self) -> str:
+        if not self._token:
+            raise RuntimeError("Not authenticated — call authenticate() first.")
+        return self._token
+
+    @_retrying
+    def authenticate(self) -> None:
+        t0 = time.monotonic()
+        log.info("Step 1: Authenticating with Salesforce (%s)", self.instance_url)
+        resp = requests.post(
+            f"{self.instance_url}/services/oauth2/token",
+            data={
+                "grant_type":    "client_credentials",
+                "client_id":     self.client_id,
+                "client_secret": self.client_secret,
+            },
+            verify=True,
+            timeout=30,
+        )
+        try:
+            data = resp.json()
+        except ValueError:
+            resp.raise_for_status()
+            raise RuntimeError(
+                f"Salesforce auth returned non-JSON response (status={resp.status_code})"
+            )
+        if "error" in data:
+            raise RuntimeError(
+                f"Salesforce auth failed: {data.get('error')} — {data.get('error_description')}"
+            )
+        resp.raise_for_status()
+        self._token = data["access_token"]
+        log.info("  Authenticated (%.1fs)", time.monotonic() - t0)
+
+    @_retrying
+    def _fetch_dataspaces_raw(self) -> requests.Response:
+        resp = requests.get(
+            f"{self.instance_url}/services/data/v{SF_API_VERSION}/query",
+            headers={"Authorization": f"Bearer {self._token}"},
+            params={"q": "SELECT DataSpaceApiName FROM Dataspace"},
+            verify=True,
+            timeout=30,
+        )
+        # Raise on 5xx to trigger retry; 4xx (403) is handled gracefully by caller
+        if resp.status_code >= 500:
+            resp.raise_for_status()
+        return resp
+
+    def get_dataspaces(self) -> list:
+        t0 = time.monotonic()
+        log.info("Step 2: Fetching Salesforce data spaces")
+        try:
+            resp = self._fetch_dataspaces_raw()
+        except (requests.exceptions.RequestException, RuntimeError) as exc:
+            log.warning(
+                "  Dataspace query failed: %s — using 'default' as fallback", exc
+            )
+            return ["default"]
+
+        if resp.status_code == 200:
+            records = resp.json().get("records", [])
+            spaces = [r["DataSpaceApiName"] for r in records if r.get("DataSpaceApiName")]
+            if spaces:
+                log.info(
+                    "  Found %d data space(s): %s (%.1fs)",
+                    len(spaces), spaces, time.monotonic() - t0,
+                )
+                return spaces
+            log.warning("  Dataspace query returned no records — using 'default' as fallback")
+            return ["default"]
+        if resp.status_code == 403:
+            log.warning(
+                "  Dataspace query returned 403 Forbidden — the connected app may lack "
+                "'Manage Data Cloud' or 'API Access' permissions. "
+                "Salesforce error: %s. Falling back to 'default'. "
+                "Edges without <dataSpace> in XML may land in the wrong data space.",
+                resp.text[:300],
+            )
+        else:
+            log.warning(
+                "  Could not query Dataspace object (status=%d, body=%s) — using 'default' as fallback",
+                resp.status_code, resp.text[:200],
+            )
+        return ["default"]
+
+    @_retrying
+    def _soap_post(self, body: str, action: str) -> ET.Element:
+        url = f"{self.instance_url}/services/Soap/m/{SF_API_VERSION}"
+        resp = requests.post(
+            url,
+            data=body.encode("utf-8"),
+            headers={"Content-Type": "text/xml", "SOAPAction": action},
+            verify=True,
+            timeout=60,
+        )
+        resp.raise_for_status()
+        root = SafeET.fromstring(resp.text)
+        fault = root.find(".//soapenv:Fault", SOAP_NS)
+        if fault is not None:
+            code = fault.findtext("faultcode", default="unknown")
+            msg  = fault.findtext("faultstring", default="no detail")
+            raise RuntimeError(f"Salesforce SOAP fault [{code}]: {msg}")
+        return root
+
+    def fetch_metadata(self) -> bytes:
+        t0 = time.monotonic()
+        log.info("Step 3: Retrieving ObjectSourceTargetMap metadata from Salesforce")
+
+        envelope = _RETRIEVE_ENVELOPE.format(
+            session_id=escape(self._token),
+            api_version=escape(SF_API_VERSION),
+        )
+        root = self._soap_post(envelope, action="retrieve")
+
+        async_id_el = root.find(".//met:id", SOAP_NS)
+        if async_id_el is None:
+            fault_el = root.find(".//met:error", SOAP_NS)
+            detail = ET.tostring(fault_el, encoding="unicode") if fault_el is not None else "no error element"
+            raise RuntimeError(f"Retrieve returned no async ID. Detail: {detail}")
+        async_id = async_id_el.text
+        if not async_id:
+            raise RuntimeError("Salesforce returned an empty async job ID for the metadata retrieve.")
+        log.info("  Retrieve job started (id=%s)", async_id)
+
+        consecutive_failures = 0
+        max_consecutive = 5
+
+        for attempt in range(METADATA_MAX_POLLS):
+            status_body = _STATUS_ENVELOPE.format(
+                session_id=escape(self._token),
+                async_id=escape(async_id),
+            )
+            try:
+                status_root = self._soap_post(status_body, action="checkRetrieveStatus")
+                consecutive_failures = 0
+            except (requests.exceptions.RequestException, RuntimeError) as exc:
+                consecutive_failures += 1
+                log.warning(
+                    "  Poll %d failed (consecutive=%d/%d): %s",
+                    attempt + 1, consecutive_failures, max_consecutive, exc,
+                )
+                if consecutive_failures >= max_consecutive:
+                    raise RuntimeError(
+                        f"Metadata poll failed {max_consecutive} consecutive times. "
+                        f"Last error: {exc}. Async job ID: {async_id}"
+                    ) from exc
+                time.sleep(METADATA_POLL_INTERVAL)
+                continue
+
+            done_el  = status_root.find(".//met:done",   SOAP_NS)
+            state_el = status_root.find(".//met:status", SOAP_NS)
+            state    = state_el.text if state_el is not None else "unknown"
+
+            if done_el is None:
+                log.warning(
+                    "  Poll %d: SOAP response missing <done> element — treating as not done",
+                    attempt + 1,
+                )
+
+            if done_el is not None and done_el.text == "true":
+                if state == "Failed":
+                    err_code = status_root.findtext(".//met:errorStatusCode", default="", namespaces=SOAP_NS)
+                    err_msg  = status_root.findtext(".//met:errorMessage",    default="", namespaces=SOAP_NS)
+                    raise RuntimeError(f"Salesforce retrieve job failed [{err_code}]: {err_msg}")
+                zip_el = status_root.find(".//met:zipFile", SOAP_NS)
+                if zip_el is None or not zip_el.text:
+                    raise RuntimeError("Retrieve completed but ZIP payload is empty.")
+                log.info("  Retrieved after %d poll(s) (%.1fs)", attempt + 1, time.monotonic() - t0)
+                return base64.b64decode(zip_el.text)
+
+            if attempt % 5 == 0:
+                log.info(
+                    "  Waiting for Salesforce metadata retrieve... poll %d/%d (status=%s)",
+                    attempt + 1, METADATA_MAX_POLLS, state,
+                )
+            else:
+                log.debug("  Poll %d/%d status=%s", attempt + 1, METADATA_MAX_POLLS, state)
+            if attempt < METADATA_MAX_POLLS - 1:
+                time.sleep(METADATA_POLL_INTERVAL)
+
+        raise TimeoutError(
+            f"Metadata retrieve did not complete within "
+            f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s. Async job ID: {async_id}. "
+            f"Increase METADATA_MAX_POLLS or METADATA_POLL_INTERVAL, or check Salesforce org status."
+        )
+
+    def parse_edges(self, zip_bytes: bytes, fallback_dataspace: str) -> list:
+        """
+        Parse DLO->DMO edges from the ObjectSourceTargetMap ZIP payload.
+
+        Data space resolution order per record:
+          1. <dataSpace> XML field (preferred — present in most orgs)
+          2. fallback_dataspace (SF_DEFAULT_DATA_SPACE env var, default: 'default')
+        """
+        t0 = time.monotonic()
+        log.info("Step 4: Parsing DLO->DMO edges from metadata")
+        edges = []
+        skipped = 0
+        xml_had_dataspace = 0
+
+        buf = io.BytesIO(zip_bytes)
+        try:
+            zf_handle = zipfile.ZipFile(buf)
+        except zipfile.BadZipFile as exc:
+            raise RuntimeError(f"Retrieved payload is not a valid ZIP: {exc}") from exc
+
+        with zf_handle as zf:
+            all_names = zf.namelist()
+            if len(all_names) > ZIP_MAX_FILES:
+                raise RuntimeError(
+                    f"ZIP contains {len(all_names)} files — exceeds safety limit of {ZIP_MAX_FILES}. "
+                    "Aborting to prevent decompression bomb."
+                )
+            total_uncompressed = sum(i.file_size for i in zf.infolist())
+            if total_uncompressed > ZIP_MAX_BYTES:
+                raise RuntimeError(
+                    f"ZIP total uncompressed size {total_uncompressed / 1024 / 1024:.0f}MB "
+                    f"exceeds safety limit of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
+                )
+
+            xml_files = [n for n in all_names if n.endswith(".objectSourceTargetMap")]
+            meta_xml_count = sum(
+                1 for n in all_names if n.endswith(".objectSourceTargetMap-meta.xml")
+            )
+            if meta_xml_count:
+                log.debug(
+                    "  Skipping %d .objectSourceTargetMap-meta.xml file(s) (metadata sidecar, not parsed)",
+                    meta_xml_count,
+                )
+
+            if not xml_files:
+                raise RuntimeError(
+                    "ZIP contained no .objectSourceTargetMap files. "
+                    "Check that the retrieve succeeded and the metadata type name is correct. "
+                    "Run with LOG_LEVEL=DEBUG to inspect the ZIP contents."
+                )
+            log.info("  Found %d ObjectSourceTargetMap record(s)", len(xml_files))
+
+            for name in xml_files:
+                with zf.open(name) as f:
+                    try:
+                        root = SafeET.parse(f).getroot()
+                    except ET.ParseError as exc:
+                        log.warning("  Skipping %s: XML parse error: %s", name, exc)
+                        skipped += 1
+                        continue
+
+                source = root.findtext("sf:sourceObjectName", namespaces=OSTM_NS)
+                target = root.findtext("sf:targetObjectName", namespaces=OSTM_NS)
+
+                if not source or not target:
+                    log.warning("  Skipping %s: missing sourceObjectName or targetObjectName", name)
+                    skipped += 1
+                    continue
+
+                if not (source.endswith("__dll") and target.endswith("__dlm")):
+                    continue
+
+                data_space = root.findtext("sf:dataSpace", namespaces=OSTM_NS)
+                if data_space:
+                    xml_had_dataspace += 1
+                else:
+                    data_space = fallback_dataspace
+
+                edges.append({"source": source, "target": target, "data_space": data_space})
+
+        buf.close()  # ZipFile.__exit__ does not close the underlying BytesIO buffer
+
+        if skipped and skipped == len(xml_files):
+            raise RuntimeError(
+                f"All {skipped} ObjectSourceTargetMap record(s) failed to parse. "
+                "Check Salesforce connectivity and metadata type availability."
+            )
+        if skipped:
+            log.warning("  Skipped %d record(s) due to parse errors", skipped)
+        if xml_had_dataspace:
+            log.info("  Data space resolved from XML: %d/%d edge(s)", xml_had_dataspace, len(edges))
+        if xml_had_dataspace < len(edges):
+            no_space_count = len(edges) - xml_had_dataspace
+            log.warning(
+                "  %d/%d edge(s) have no <dataSpace> in XML — using fallback '%s'. "
+                "If your org uses multiple data spaces, set SF_DEFAULT_DATA_SPACE to match "
+                "or contact your Salesforce admin to confirm the data space name.",
+                no_space_count, len(edges), fallback_dataspace,
+            )
+        log.info("  %d DLO->DMO edge(s) extracted (%.1fs)", len(edges), time.monotonic() - t0)
+        return edges
+
+
+# ── Monte Carlo lineage service ───────────────────────────────────────────────
+class SalesforceDataCloudLineageService:
+    """Encapsulates MC catalog validation and lineage push."""
+
+    def __init__(
+        self,
+        resource_uuid: str,
+        ingest_key_id: str,
+        ingest_key_secret: str,
+        gql_key_id: str,
+        gql_key_secret: str,
+    ) -> None:
+        self.resource_uuid = resource_uuid
+        self.ingest_key_id = ingest_key_id
+        self.ingest_key_secret = ingest_key_secret
+        self.gql_key_id = gql_key_id
+        self.gql_key_secret = gql_key_secret
+
+    @_retrying
+    def _gql(self, query: str, variables: Optional[dict] = None) -> dict:
+        payload: dict = {"query": query}
+        if variables:
+            payload["variables"] = variables
+        resp = requests.post(
+            MC_GRAPHQL_URL,
+            json=payload,
+            headers={
+                "x-mcd-id":     self.gql_key_id,
+                "x-mcd-token":  self.gql_key_secret,
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+            verify=True,
+        )
+        resp.raise_for_status()
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"MC GraphQL returned non-JSON response (status={resp.status_code}). "
+                f"Response preview: {resp.text[:200]}"
+            ) from exc
+        if "errors" in body:
+            msgs = [e.get("message", str(e)) for e in body["errors"]]
+            raise RuntimeError(
+                f"MC GraphQL error: {'; '.join(msgs)}. "
+                "Check that MCD_ID/MCD_TOKEN are a Personal API key (not an Ingestion key)."
+            )
+        return body["data"]
+
+    def _fetch_mc_catalog(self) -> dict:
+        """
+        Fetch ALL tables for the warehouse from MC in one paginated bulk query.
+        Scoping by dwId prevents cross-org contamination when multiple Data Cloud orgs
+        are connected to the same MC account.
+        Returns dict of {table_name_lower → data_space_or_list}.
+        """
+        catalog: dict = {}
+        after = None
+        page = 0
+
+        while True:
+            page += 1
+            variables: dict = {"dwId": self.resource_uuid}
+            if after:
+                variables["after"] = after
+
+            data = self._gql(
+                """
+                query GetAllTables($dwId: UUID, $after: String) {
+                  getTables(first: 200, dwId: $dwId, after: $after) {
+                    edges { node { fullTableId dataset } }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+                """,
+                variables=variables,
+            )
+
+            result = data.get("getTables") or {}
+            for edge in (result.get("edges") or []):
+                node = edge.get("node") or {}
+                raw_id = node.get("fullTableId") or ""
+                if not raw_id.lower().startswith(DB + ":") or "." not in raw_id:
+                    continue
+                table_name = raw_id.rsplit(".", 1)[1].lower()
+                # dataset field is authoritative; fall back to parsing fullTableId
+                data_space = node.get("dataset") or raw_id.split(":", 1)[1].rsplit(".", 1)[0]
+                if table_name in catalog:
+                    existing = catalog[table_name]
+                    if isinstance(existing, list):
+                        existing.append(data_space)
+                    else:
+                        catalog[table_name] = [existing, data_space]
+                else:
+                    catalog[table_name] = data_space
+
+            log.info("  Catalog fetch page %d: %d table(s) retrieved so far", page, len(catalog))
+
+            page_info = result.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            after = page_info.get("endCursor")
+            if not after:
+                log.warning(
+                    "  MC catalog hasNextPage=true but endCursor is null — "
+                    "stopping pagination to avoid infinite loop"
+                )
+                break
+
+        return catalog
+
+    def _resolve_catalog(
+        self,
+        catalog: dict,
+        table_name: str,
+        preferred_data_space: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return data_space for table_name, or None if not in catalog."""
+        entry = catalog.get(table_name.lower())
+        if entry is None:
+            return None
+        if isinstance(entry, list):
+            if preferred_data_space and preferred_data_space in entry:
+                return preferred_data_space
+            log.warning(
+                "  Table '%s' found in multiple data spaces in MC catalog: %s — "
+                "using '%s'. If edges land in the wrong data space, check which "
+                "data space the DLO→DMO mapping belongs to and set SF_DEFAULT_DATA_SPACE.",
+                table_name, entry, entry[0],
+            )
+            return entry[0]
+        return entry
+
+    def validate_edges(self, edges: list) -> list:
+        """
+        Fetch all tables for the warehouse from MC in bulk, then validate each edge.
+        Extracts the authoritative data space from each table's MC catalog dataset field
+        and stamps it onto the returned edges — overriding the XML fallback from parse_edges().
+        Edges where either table is missing from the MC catalog, or where DLO and DMO
+        are catalogued under different data spaces, are removed and logged.
+        Returns the validated subset ready for push.
+        """
+        if not edges:
+            return edges
+
+        log.info("Step 4b: Validating DLO and DMO tables exist in Monte Carlo catalog")
+        t0 = time.monotonic()
+
+        try:
+            mc_catalog = self._fetch_mc_catalog()
+        except requests.exceptions.HTTPError as exc:
+            raise RuntimeError(
+                f"MC catalog fetch returned {exc.response.status_code}. "
+                "Check MCD_ID/MCD_TOKEN."
+            ) from exc
+        except requests.exceptions.RequestException as exc:
+            raise RuntimeError(
+                f"Network error fetching MC catalog: {exc}. "
+                "Check connectivity to https://api.getmontecarlo.com"
+            ) from exc
+
+        log.info(
+            "  Fetched %d table(s) from MC catalog (%.1fs)",
+            len(mc_catalog), time.monotonic() - t0,
+        )
+
+        unique_names = sorted({e["source"] for e in edges} | {e["target"] for e in edges})
+        missing_set: set = set()
+
+        for name in unique_names:
+            if mc_catalog.get(name.lower()) is not None:
+                entry = mc_catalog[name.lower()]
+                ds = entry[0] if isinstance(entry, list) else entry
+                log.debug("  Found in MC catalog: %s (data space: %s)", name, ds)
+            else:
+                missing_set.add(name)
+                log.warning(
+                    "  NOT in MC catalog: %s — edge(s) using this table will be skipped. "
+                    "Confirm the Data Cloud connector has completed a metadata scan in Monte Carlo.",
+                    name,
+                )
+
+        matched = len(unique_names) - len(missing_set)
+        log.info(
+            "  Catalog check complete: %d matched, %d not in catalog (%.1fs)",
+            matched, len(missing_set), time.monotonic() - t0,
+        )
+
+        if missing_set:
+            log.warning("  Table(s) not in MC catalog: %s", ", ".join(sorted(missing_set)))
+            log.warning(
+                "  Lineage edges for these tables will not be pushed. "
+                "Once the Data Cloud connector syncs them, re-run this script "
+                "to push their edges (the push is idempotent — already-pushed edges are safe to re-send)."
+            )
+
+        valid = []
+        catalog_skips = 0
+        mismatch_skips = 0
+        for e in edges:
+            preferred = e.get("data_space")
+            src_space = self._resolve_catalog(mc_catalog, e["source"], preferred_data_space=preferred)
+            tgt_space = self._resolve_catalog(mc_catalog, e["target"], preferred_data_space=preferred)
+            if src_space is None or tgt_space is None:
+                catalog_skips += 1
+                continue
+            if src_space != tgt_space:
+                log.warning(
+                    "  Data space mismatch: %s is in '%s' but %s is in '%s' — skipping edge",
+                    e["source"], src_space, e["target"], tgt_space,
+                )
+                mismatch_skips += 1
+                continue
+            valid.append({**e, "data_space": src_space})
+
+        if catalog_skips:
+            log.warning("  %d edge(s) skipped (table(s) not yet in MC catalog)", catalog_skips)
+        if mismatch_skips:
+            log.warning("  %d edge(s) skipped (DLO/DMO data space mismatch in MC catalog)", mismatch_skips)
+        if valid:
+            log.info("  %d edge(s) ready to push", len(valid))
+        return valid
+
+    @_retrying
+    def _send_batch(self, svc: IngestionService, events: list) -> object:
+        return svc.send_lineage(
+            resource_uuid=self.resource_uuid,
+            resource_type=DC_RESOURCE_TYPE,
+            events=events,
+        )
+
+    def push_edges(self, edges: list, run_id: str) -> list:
+        t0 = time.monotonic()
+        log.info("Step 5: Pushing %d DLO->DMO edge(s) via Ingest API", len(edges))
+
+        svc = IngestionService(mc_client=Client(session=Session(
+            mcd_id=self.ingest_key_id,
+            mcd_token=self.ingest_key_secret,
+            scope="Ingestion",
+            endpoint=MC_INGEST_URL,
+        )))
+
+        events = [
+            LineageEvent(
+                destination=LineageAssetRef(
+                    type="TABLE",
+                    database=DB,
+                    schema=e["data_space"],
+                    name=e["target"],
+                ),
+                sources=[LineageAssetRef(
+                    type="TABLE",
+                    database=DB,
+                    schema=e["data_space"],
+                    name=e["source"],
+                )],
+            )
+            for e in edges
+        ]
+
+        invocation_ids: list = []
+        failures: list = []
+        total_batches = (len(events) + INGEST_BATCH_SIZE - 1) // INGEST_BATCH_SIZE
+
+        for i in range(0, len(events), INGEST_BATCH_SIZE):
+            batch_events = events[i : i + INGEST_BATCH_SIZE]
+            batch_edges  = edges[i : i + INGEST_BATCH_SIZE]
+            batch_num    = i // INGEST_BATCH_SIZE + 1
+            try:
+                resp = self._send_batch(svc, batch_events)
+                inv_id = svc.extract_invocation_id(resp)
+                invocation_ids.append(inv_id)
+                log.info(
+                    "  Batch %d/%d: %d edge(s) pushed — invocation_id=%s",
+                    batch_num, total_batches, len(batch_events), inv_id,
+                )
+            except Exception as exc:
+                log.error("  Batch %d/%d failed: %s", batch_num, total_batches, exc)
+                failures.extend(batch_edges)
+
+        if failures:
+            path = _save_failed_edges(run_id, "dlo_dmo", failures)
+            raise RuntimeError(
+                f"{len(failures)} DLO->DMO edge(s) failed to push. "
+                f"Failed edges saved for retry: {path}"
+            )
+        log.info("  All %d DLO->DMO edge(s) pushed (%.1fs)", len(edges), time.monotonic() - t0)
+        return invocation_ids
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main() -> None:
+    run_id = uuid.uuid4().hex[:8]
+    global log
+    log = _setup_logging(run_id)
+
+    parser = argparse.ArgumentParser(
+        description="Push Salesforce Data 360 DLO->DMO lineage to Monte Carlo"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch live data and preview edges, but skip the MC push",
+    )
+    args = parser.parse_args()
+
+    def _handle_sigterm(signum, frame):  # noqa: ANN001
+        log.warning("Received SIGTERM — shutting down. Partial lineage edges may have been pushed.")
+        sys.exit(1)
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+    log.info(
+        "=== Data 360 Lineage Push | run_id=%s%s ===",
+        run_id, " [DRY RUN]" if args.dry_run else "",
+    )
+    t_start = time.monotonic()
+
+    sf_instance_url   = _require("SF_ORG_URL")
+    sf_client_id      = _require("SF_CLIENT_ID")
+    sf_client_secret  = _require("SF_CLIENT_SECRET")
+    mcd_ingest_id     = _require("MCD_INGEST_ID")
+    mcd_ingest_token  = _require("MCD_INGEST_TOKEN")
+    mcd_id            = _require("MCD_ID")
+    mcd_token         = _require("MCD_TOKEN")
+    mcd_resource_uuid = _require("MCD_RESOURCE_UUID")
+
+    # SSRF guard: reject non-HTTPS, embedded credentials, private/reserved IPs (literal and DNS)
+    _parsed_url = urlparse(sf_instance_url)
+    if _parsed_url.scheme != "https" or not _parsed_url.hostname or "@" in (_parsed_url.netloc or ""):
+        log.error(
+            "SF_ORG_URL is not a valid HTTPS URL (got: %s). "
+            "Expected format: https://myorg.my.salesforce.com",
+            sf_instance_url,
+        )
+        sys.exit(1)
+
+    _hostname = _parsed_url.hostname
+    if _hostname.lower() == "localhost":
+        log.error("SF_ORG_URL hostname is 'localhost' — refusing to connect.")
+        sys.exit(1)
+
+    def _is_internal_ip(addr) -> bool:
+        return (
+            addr.is_private
+            or addr.is_loopback
+            or addr.is_link_local
+            or addr.is_reserved
+            or addr.is_multicast
+        )
+
+    try:
+        _sf_addr = ipaddress.ip_address(_hostname)
+        if _is_internal_ip(_sf_addr):
+            log.error(
+                "SF_ORG_URL hostname is a private/loopback/reserved IP (%s) — refusing to connect. "
+                "SF_ORG_URL must be a Salesforce My Domain URL, not an internal address.",
+                _hostname,
+            )
+            sys.exit(1)
+    except ValueError:
+        # Domain name — resolve and check all returned IPs
+        try:
+            for _family, _type, _proto, _canonname, _sockaddr in socket.getaddrinfo(_hostname, None):
+                _ip_str = _sockaddr[0]
+                try:
+                    _resolved = ipaddress.ip_address(_ip_str)
+                    if _is_internal_ip(_resolved):
+                        log.error(
+                            "SF_ORG_URL hostname '%s' resolves to a private/reserved IP (%s) — "
+                            "refusing to connect.",
+                            _hostname, _ip_str,
+                        )
+                        sys.exit(1)
+                except ValueError:
+                    pass
+        except socket.gaierror:
+            pass  # DNS failure — let the actual request surface a clear network error
+
+    default_dataspace = os.environ.get("SF_DEFAULT_DATA_SPACE", "default")
+
+    sf_svc = SalesforceDataCloudService(sf_instance_url, sf_client_id, sf_client_secret)
+    lineage_svc = SalesforceDataCloudLineageService(
+        resource_uuid=mcd_resource_uuid,
+        ingest_key_id=mcd_ingest_id,
+        ingest_key_secret=mcd_ingest_token,
+        gql_key_id=mcd_id,
+        gql_key_secret=mcd_token,
+    )
+
+    try:
+        # Steps 1-2
+        sf_svc.authenticate()
+
+        data_spaces = sf_svc.get_dataspaces()
+        # Single data space: use it directly. Multiple: XML <dataSpace> is authoritative;
+        # default_dataspace (SF_DEFAULT_DATA_SPACE) is a last-resort fallback only.
+        fallback_space = data_spaces[0] if len(data_spaces) == 1 else default_dataspace
+        if len(data_spaces) > 1:
+            log.info(
+                "  Multiple data spaces — DLO records without <dataSpace> will use '%s'",
+                fallback_space,
+            )
+
+        # Steps 3-4b
+        zip_bytes = sf_svc.fetch_metadata()
+        dlo_edges = sf_svc.parse_edges(zip_bytes, fallback_space)
+        dlo_edges = lineage_svc.validate_edges(dlo_edges)
+
+    except (RuntimeError, TimeoutError, requests.exceptions.RequestException) as exc:
+        log.error("Fatal error during data collection: %s", exc)
+        sys.exit(1)
+    except Exception as exc:
+        log.exception("Unexpected error during data collection: %s", exc)
+        sys.exit(2)
+
+    log.info("DLO->DMO edges (%d total):", len(dlo_edges))
+    for e in dlo_edges:
+        log.info("  [%s] %s -> %s", e["data_space"], e["source"], e["target"])
+
+    if not dlo_edges:
+        log.warning(
+            "0 DLO->DMO edges ready to push. "
+            "If Step 4b removed all edges: trigger a metadata sync in Monte Carlo "
+            "(Settings → Integrations → your Data Cloud connection) then re-run. "
+            "If Step 4 also found 0 edges: confirm DLO→DMO mappings exist in your Salesforce org."
+        )
+        sys.exit(0)
+
+    if args.dry_run:
+        log.info(
+            "[dry-run] Would push %d DLO->DMO edge(s) to Monte Carlo warehouse UUID=%s. "
+            "Run without --dry-run to commit.",
+            len(dlo_edges), mcd_resource_uuid,
+        )
+        sys.exit(0)
+
+    try:
+        all_invocation_ids = lineage_svc.push_edges(dlo_edges, run_id)
+    except KeyboardInterrupt:
+        log.warning("Interrupted during push — partial results may have been written to Monte Carlo.")
+        sys.exit(1)
+    except RuntimeError as exc:
+        log.error("Push failed: %s", exc)
+        sys.exit(1)
+    except Exception as exc:
+        log.exception("Unexpected error during push: %s", exc)
+        sys.exit(2)
+
+    elapsed = time.monotonic() - t_start
+    log.info(
+        "=== Run complete | run_id=%s | %.1fs | DLO->DMO=%d | invocation_ids=[%s] ===",
+        run_id, elapsed,
+        len(dlo_edges),
+        ", ".join(str(iid) for iid in all_invocation_ids if iid is not None) or "none",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -25,7 +25,8 @@ Optional env vars:
   LOG_LEVEL              — DEBUG/INFO/WARNING/ERROR (default: INFO)
   LOG_FORMAT             — json for structured output (default: plain)
   INGEST_BATCH_SIZE      — edges per push batch (default: 500)
-  METADATA_MAX_POLLS     — max SOAP polling attempts (default: 120)
+  METADATA_BATCH_SIZE    — ObjectSourceTargetMap records per retrieve batch (default: 10)
+  METADATA_MAX_POLLS     — max SOAP polling attempts per batch (default: 120)
   METADATA_POLL_INTERVAL — seconds between SOAP polls (default: 5)
   SF_DEFAULT_DATA_SPACE  — fallback data space name (default: default)
 """
@@ -107,6 +108,7 @@ def _parse_positive_float(name: str, default: float) -> float:
 
 
 INGEST_BATCH_SIZE      = _parse_positive_int("INGEST_BATCH_SIZE", 500)
+METADATA_BATCH_SIZE    = _parse_positive_int("METADATA_BATCH_SIZE", 10)
 METADATA_MAX_POLLS     = _parse_positive_int("METADATA_MAX_POLLS", 120)
 METADATA_POLL_INTERVAL = _parse_positive_float("METADATA_POLL_INTERVAL", 5.0)
 
@@ -120,7 +122,23 @@ SOAP_NS = {
 }
 
 # ── SOAP envelope templates ───────────────────────────────────────────────────
-_RETRIEVE_ENVELOPE = """\
+_LIST_METADATA_ENVELOPE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:met="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Header>
+    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
+  </soapenv:Header>
+  <soapenv:Body>
+    <met:listMetadata>
+      <met:queries><met:type>ObjectSourceTargetMap</met:type></met:queries>
+      <met:asOfVersion>{api_version}</met:asOfVersion>
+    </met:listMetadata>
+  </soapenv:Body>
+</soapenv:Envelope>"""
+
+_RETRIEVE_BATCH_ENVELOPE = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
@@ -134,7 +152,7 @@ _RETRIEVE_ENVELOPE = """\
         <met:apiVersion>{api_version}</met:apiVersion>
         <met:unpackaged>
           <met:types>
-            <met:members>*</met:members>
+            {members}
             <met:name>ObjectSourceTargetMap</met:name>
           </met:types>
         </met:unpackaged>
@@ -262,6 +280,13 @@ def _save_failed_edges(run_id: str, kind: str, edges: list) -> str:
     return str(path)
 
 
+def _format_eta(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    mins, secs = divmod(int(seconds), 60)
+    return f"{mins}m {secs:02d}s"
+
+
 # ── Salesforce service ────────────────────────────────────────────────────────
 class SalesforceDataCloudService:
     """Encapsulates Salesforce authentication and metadata retrieval."""
@@ -377,26 +402,38 @@ class SalesforceDataCloudService:
             raise RuntimeError(f"Salesforce SOAP fault [{code}]: {msg}")
         return root
 
-    def fetch_metadata(self) -> bytes:
-        t0 = time.monotonic()
-        log.info("Step 3: Retrieving ObjectSourceTargetMap metadata from Salesforce")
-
-        envelope = _RETRIEVE_ENVELOPE.format(
+    def _list_ostm_names(self) -> list:
+        """Call listMetadata to get all ObjectSourceTargetMap record names. Completes in <1s."""
+        envelope = _LIST_METADATA_ENVELOPE.format(
             session_id=escape(self._token),
             api_version=escape(SF_API_VERSION),
         )
-        root = self._soap_post(envelope, action="retrieve")
+        root = self._soap_post(envelope, action="listMetadata")
+        return [
+            el.text
+            for el in root.findall(".//{http://soap.sforce.com/2006/04/metadata}fullName")
+            if el.text
+        ]
 
+    def _submit_retrieve(self, members_xml: str) -> str:
+        """Submit a retrieve job for specific members and return the async job ID."""
+        envelope = _RETRIEVE_BATCH_ENVELOPE.format(
+            session_id=escape(self._token),
+            api_version=escape(SF_API_VERSION),
+            members=members_xml,
+        )
+        root = self._soap_post(envelope, action="retrieve")
         async_id_el = root.find(".//met:id", SOAP_NS)
         if async_id_el is None:
             fault_el = root.find(".//met:error", SOAP_NS)
             detail = ET.tostring(fault_el, encoding="unicode") if fault_el is not None else "no error element"
             raise RuntimeError(f"Retrieve returned no async ID. Detail: {detail}")
-        async_id = async_id_el.text
-        if not async_id:
+        if not async_id_el.text:
             raise RuntimeError("Salesforce returned an empty async job ID for the metadata retrieve.")
-        log.info("  Retrieve job started (id=%s)", async_id)
+        return async_id_el.text
 
+    def _poll_retrieve(self, async_id: str, label: str) -> bytes:
+        """Poll a retrieve job until complete and return ZIP bytes."""
         consecutive_failures = 0
         max_consecutive = 5
 
@@ -411,8 +448,8 @@ class SalesforceDataCloudService:
             except (requests.exceptions.RequestException, RuntimeError) as exc:
                 consecutive_failures += 1
                 log.warning(
-                    "  Poll %d failed (consecutive=%d/%d): %s",
-                    attempt + 1, consecutive_failures, max_consecutive, exc,
+                    "  %s poll %d failed (consecutive=%d/%d): %s",
+                    label, attempt + 1, consecutive_failures, max_consecutive, exc,
                 )
                 if consecutive_failures >= max_consecutive:
                     raise RuntimeError(
@@ -427,10 +464,7 @@ class SalesforceDataCloudService:
             state    = state_el.text if state_el is not None else "unknown"
 
             if done_el is None:
-                log.warning(
-                    "  Poll %d: SOAP response missing <done> element — treating as not done",
-                    attempt + 1,
-                )
+                log.warning("  %s poll %d: missing <done> element — treating as not done", label, attempt + 1)
 
             if done_el is not None and done_el.text == "true":
                 if state == "Failed":
@@ -440,24 +474,79 @@ class SalesforceDataCloudService:
                 zip_el = status_root.find(".//met:zipFile", SOAP_NS)
                 if zip_el is None or not zip_el.text:
                     raise RuntimeError("Retrieve completed but ZIP payload is empty.")
-                log.info("  Retrieved after %d poll(s) (%.1fs)", attempt + 1, time.monotonic() - t0)
                 return base64.b64decode(zip_el.text)
 
-            if attempt % 5 == 0:
-                log.info(
-                    "  Waiting for Salesforce metadata retrieve... poll %d/%d (status=%s)",
-                    attempt + 1, METADATA_MAX_POLLS, state,
-                )
-            else:
-                log.debug("  Poll %d/%d status=%s", attempt + 1, METADATA_MAX_POLLS, state)
+            log.debug("  %s poll %d/%d status=%s", label, attempt + 1, METADATA_MAX_POLLS, state)
             if attempt < METADATA_MAX_POLLS - 1:
                 time.sleep(METADATA_POLL_INTERVAL)
 
         raise TimeoutError(
-            f"Metadata retrieve did not complete within "
+            f"Batch retrieve did not complete within "
             f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s. Async job ID: {async_id}. "
             f"Increase METADATA_MAX_POLLS or METADATA_POLL_INTERVAL, or check Salesforce org status."
         )
+
+    def fetch_metadata(self) -> bytes:
+        t0 = time.monotonic()
+        log.info("Step 3: Retrieving ObjectSourceTargetMap metadata from Salesforce")
+
+        # Fast list to discover all record names (~0.5s)
+        names = self._list_ostm_names()
+        if not names:
+            log.warning("  listMetadata returned 0 ObjectSourceTargetMap records")
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w"):
+                pass
+            return buf.getvalue()
+
+        batches = [names[i:i + METADATA_BATCH_SIZE] for i in range(0, len(names), METADATA_BATCH_SIZE)]
+        total_batches = len(batches)
+        log.info(
+            "  Found %d ObjectSourceTargetMap record(s) — retrieving in %d batch(es) of up to %d",
+            len(names), total_batches, METADATA_BATCH_SIZE,
+        )
+
+        combined_buf = io.BytesIO()
+        combined_zip = zipfile.ZipFile(combined_buf, "w", zipfile.ZIP_DEFLATED)
+        batch_times: list = []
+
+        for i, batch in enumerate(batches):
+            batch_num = i + 1
+            batch_t0 = time.monotonic()
+            members_xml = "\n            ".join(
+                f"<met:members>{escape(n)}</met:members>" for n in batch
+            )
+            async_id = self._submit_retrieve(members_xml)
+            log.debug("  Batch %d/%d submitted (id=%s)", batch_num, total_batches, async_id)
+
+            zip_bytes = self._poll_retrieve(async_id, label=f"Batch {batch_num}/{total_batches}")
+            batch_elapsed = time.monotonic() - batch_t0
+            batch_times.append(batch_elapsed)
+
+            # Rolling average ETA over last 5 batches
+            window = batch_times[-5:]
+            avg = sum(window) / len(window)
+            remaining = total_batches - batch_num
+            if remaining > 0:
+                log.info(
+                    "  Batch %d/%d complete (%d record(s), %.1fs) — est. %s remaining",
+                    batch_num, total_batches, len(batch), batch_elapsed, _format_eta(avg * remaining),
+                )
+            else:
+                log.info(
+                    "  Batch %d/%d complete (%d record(s), %.1fs)",
+                    batch_num, total_batches, len(batch), batch_elapsed,
+                )
+
+            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as batch_zf:
+                for name in batch_zf.namelist():
+                    if name.endswith("package.xml"):
+                        continue  # skip sidecar manifest — one copy already present
+                    combined_zip.writestr(name, batch_zf.read(name))
+
+        combined_zip.close()
+        log.info("  All %d record(s) retrieved in %.1fs", len(names), time.monotonic() - t0)
+        return combined_buf.getvalue()
 
     def parse_edges(self, zip_bytes: bytes, fallback_dataspace: str) -> list:
         """

--- a/examples/push-ingestion/salesforce-data-cloud/requirements.txt
+++ b/examples/push-ingestion/salesforce-data-cloud/requirements.txt
@@ -1,0 +1,5 @@
+requests>=2.31.0
+python-dotenv>=1.0.0
+pycarlo>=0.12.251
+tenacity>=8.2.0
+defusedxml>=0.7.1

--- a/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
+++ b/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
@@ -37,8 +37,9 @@ except ImportError as err:
 load_dotenv(dotenv_path=Path(__file__).parent / ".env")
 
 SF_API_VERSION = "62.0"
-METADATA_MAX_POLLS = 120
-METADATA_POLL_INTERVAL = 5.0
+METADATA_BATCH_SIZE = int(os.environ.get("METADATA_BATCH_SIZE", "10"))
+METADATA_MAX_POLLS = int(os.environ.get("METADATA_MAX_POLLS", "120"))
+METADATA_POLL_INTERVAL = float(os.environ.get("METADATA_POLL_INTERVAL", "5.0"))
 
 SOAP_NS = {
     "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
@@ -46,7 +47,23 @@ SOAP_NS = {
 }
 OSTM_NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
 
-_RETRIEVE_ENVELOPE = """\
+_LIST_METADATA_ENVELOPE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:met="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Header>
+    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
+  </soapenv:Header>
+  <soapenv:Body>
+    <met:listMetadata>
+      <met:queries><met:type>ObjectSourceTargetMap</met:type></met:queries>
+      <met:asOfVersion>{api_version}</met:asOfVersion>
+    </met:listMetadata>
+  </soapenv:Body>
+</soapenv:Envelope>"""
+
+_RETRIEVE_BATCH_ENVELOPE = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
@@ -60,7 +77,7 @@ _RETRIEVE_ENVELOPE = """\
         <met:apiVersion>{api_version}</met:apiVersion>
         <met:unpackaged>
           <met:types>
-            <met:members>*</met:members>
+            {members}
             <met:name>ObjectSourceTargetMap</met:name>
           </met:types>
         </met:unpackaged>
@@ -99,6 +116,68 @@ def _warn(msg): print(f"  [WARN] {msg}")
 def _fail(msg): print(f"  [FAIL] {msg}")
 
 
+def _format_eta(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    mins, secs = divmod(int(seconds), 60)
+    return f"{mins}m {secs:02d}s"
+
+
+def _soap_post(url: str, envelope: str, action: str) -> ET.Element:
+    resp = requests.post(
+        url,
+        data=envelope.encode("utf-8"),
+        headers={"Content-Type": "text/xml", "SOAPAction": action},
+        timeout=60,
+        verify=True,
+    )
+    resp.raise_for_status()
+    root = SafeET.fromstring(resp.text)
+    fault = root.find(".//soapenv:Fault", SOAP_NS)
+    if fault is not None:
+        code = fault.findtext("faultcode", default="unknown")
+        msg  = fault.findtext("faultstring", default="no detail")
+        _fail(f"SOAP fault [{code}]: {msg}")
+        sys.exit(1)
+    return root
+
+
+def _poll_batch(url: str, token: str, async_id: str, label: str) -> bytes:
+    for attempt in range(METADATA_MAX_POLLS):
+        status_body = _STATUS_ENVELOPE.format(
+            session_id=escape(token), async_id=escape(async_id)
+        )
+        status_root = _soap_post(url, status_body, action="checkRetrieveStatus")
+
+        done_el  = status_root.find(".//met:done",   SOAP_NS)
+        state_el = status_root.find(".//met:status", SOAP_NS)
+        state    = state_el.text if state_el is not None else "unknown"
+
+        if done_el is not None and done_el.text == "true":
+            if state == "Failed":
+                err_code = status_root.findtext(".//met:errorStatusCode", default="", namespaces=SOAP_NS)
+                err_msg  = status_root.findtext(".//met:errorMessage",    default="", namespaces=SOAP_NS)
+                _fail(f"Retrieve job failed [{err_code}]: {err_msg}")
+                sys.exit(1)
+            zip_el = status_root.find(".//met:zipFile", SOAP_NS)
+            if zip_el is None or not zip_el.text:
+                _fail("Retrieve completed but ZIP payload is empty")
+                sys.exit(1)
+            return base64.b64decode(zip_el.text)
+
+        if attempt % 5 == 0:
+            elapsed_msg = f"attempt {attempt + 1}/{METADATA_MAX_POLLS}, status={state}"
+            print(f"  [....] {label}: polling... {elapsed_msg}")
+        time.sleep(METADATA_POLL_INTERVAL)
+
+    _fail(
+        f"Retrieve did not complete within "
+        f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s ({label}). "
+        f"Try increasing METADATA_MAX_POLLS (current: {METADATA_MAX_POLLS})."
+    )
+    sys.exit(1)
+
+
 def check_auth(instance_url, client_id, client_secret):
     _sep("1. OAuth — client credentials")
     t0 = time.monotonic()
@@ -106,6 +185,7 @@ def check_auth(instance_url, client_id, client_secret):
         f"{instance_url}/services/oauth2/token",
         data={"grant_type": "client_credentials", "client_id": client_id, "client_secret": client_secret},
         timeout=30,
+        verify=True,
     )
     data = resp.json()
     if "error" in data:
@@ -125,6 +205,7 @@ def check_data_spaces(instance_url, token):
         headers={"Authorization": f"Bearer {token}"},
         params={"q": "SELECT DataSpaceApiName FROM Dataspace"},
         timeout=30,
+        verify=True,
     )
     elapsed = time.monotonic() - t0
     if resp.status_code != 200:
@@ -152,84 +233,81 @@ def check_data_spaces(instance_url, token):
 def check_metadata_retrieve(instance_url, token):
     _sep("3. SOAP Metadata API — ObjectSourceTargetMap retrieve")
 
-    # Submit retrieve job
+    url = f"{instance_url}/services/Soap/m/{SF_API_VERSION}"
     t0 = time.monotonic()
-    envelope = _RETRIEVE_ENVELOPE.format(
+
+    # Step 3a: list all record names via listMetadata (~0.5s)
+    list_envelope = _LIST_METADATA_ENVELOPE.format(
         session_id=escape(token), api_version=escape(SF_API_VERSION)
     )
-    url = f"{instance_url}/services/Soap/m/{SF_API_VERSION}"
-    resp = requests.post(
-        url,
-        data=envelope.encode("utf-8"),
-        headers={"Content-Type": "text/xml", "SOAPAction": "retrieve"},
-        timeout=60,
-    )
-    resp.raise_for_status()
-    root = SafeET.fromstring(resp.text)
+    list_root = _soap_post(url, list_envelope, action="listMetadata")
+    names = [
+        el.text
+        for el in list_root.findall(".//{http://soap.sforce.com/2006/04/metadata}fullName")
+        if el.text
+    ]
+    elapsed = time.monotonic() - t0
+    _ok(f"listMetadata returned {len(names)} record(s) in {elapsed:.1f}s")
 
-    fault = root.find(".//soapenv:Fault", SOAP_NS)
-    if fault is not None:
-        code = fault.findtext("faultcode", default="unknown")
-        msg  = fault.findtext("faultstring", default="no detail")
-        _fail(f"SOAP fault [{code}]: {msg}")
-        sys.exit(1)
+    if not names:
+        _warn("No ObjectSourceTargetMap records found in org")
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w"):
+            pass
+        return buf.getvalue()
 
-    async_id_el = root.find(".//met:id", SOAP_NS)
-    if async_id_el is None:
-        _fail("No async job ID returned from retrieve request")
-        sys.exit(1)
+    # Step 3b: retrieve in batches
+    batches = [names[i:i + METADATA_BATCH_SIZE] for i in range(0, len(names), METADATA_BATCH_SIZE)]
+    total_batches = len(batches)
+    _ok(f"Retrieving {len(names)} record(s) in {total_batches} batch(es) of up to {METADATA_BATCH_SIZE}")
 
-    async_id = async_id_el.text
-    _ok(f"Retrieve job submitted (id={async_id})")
+    combined_buf = io.BytesIO()
+    combined_zip = zipfile.ZipFile(combined_buf, "w", zipfile.ZIP_DEFLATED)
+    batch_times: list = []
 
-    # Poll for completion
-    zip_bytes = None
-    for attempt in range(METADATA_MAX_POLLS):
-        status_body = _STATUS_ENVELOPE.format(
-            session_id=escape(token), async_id=escape(async_id)
+    for i, batch in enumerate(batches):
+        batch_num = i + 1
+        batch_t0 = time.monotonic()
+        members_xml = "\n            ".join(
+            f"<met:members>{escape(n)}</met:members>" for n in batch
         )
-        status_resp = requests.post(
-            url,
-            data=status_body.encode("utf-8"),
-            headers={"Content-Type": "text/xml", "SOAPAction": "checkRetrieveStatus"},
-            timeout=60,
+        retrieve_envelope = _RETRIEVE_BATCH_ENVELOPE.format(
+            session_id=escape(token),
+            api_version=escape(SF_API_VERSION),
+            members=members_xml,
         )
-        status_resp.raise_for_status()
-        status_root = SafeET.fromstring(status_resp.text)
+        retrieve_root = _soap_post(url, retrieve_envelope, action="retrieve")
+        async_id_el = retrieve_root.find(".//met:id", SOAP_NS)
+        if async_id_el is None or not async_id_el.text:
+            _fail(f"Batch {batch_num}: no async job ID returned")
+            sys.exit(1)
+        async_id = async_id_el.text
 
-        done_el  = status_root.find(".//met:done",   SOAP_NS)
-        state_el = status_root.find(".//met:status", SOAP_NS)
-        state    = state_el.text if state_el is not None else "unknown"
+        zip_bytes = _poll_batch(url, token, async_id, label=f"Batch {batch_num}/{total_batches}")
+        batch_elapsed = time.monotonic() - batch_t0
+        batch_times.append(batch_elapsed)
 
-        if done_el is not None and done_el.text == "true":
-            if state == "Failed":
-                err_code = status_root.findtext(".//met:errorStatusCode", default="", namespaces=SOAP_NS)
-                err_msg  = status_root.findtext(".//met:errorMessage",    default="", namespaces=SOAP_NS)
-                _fail(f"Retrieve job failed [{err_code}]: {err_msg}")
-                sys.exit(1)
-            zip_el = status_root.find(".//met:zipFile", SOAP_NS)
-            if zip_el is None or not zip_el.text:
-                _fail("Retrieve completed but ZIP payload is empty")
-                sys.exit(1)
-            elapsed = time.monotonic() - t0
-            _ok(f"Retrieve completed after {attempt + 1} poll(s) ({elapsed:.1f}s)")
-            zip_bytes = base64.b64decode(zip_el.text)
-            break
+        window = batch_times[-5:]
+        avg = sum(window) / len(window)
+        remaining = total_batches - batch_num
+        if remaining > 0:
+            _ok(
+                f"Batch {batch_num}/{total_batches} complete ({len(batch)} record(s), "
+                f"{batch_elapsed:.1f}s) — est. {_format_eta(avg * remaining)} remaining"
+            )
+        else:
+            _ok(f"Batch {batch_num}/{total_batches} complete ({len(batch)} record(s), {batch_elapsed:.1f}s)")
 
-        if attempt % 5 == 0:
-            elapsed = time.monotonic() - t0
-            print(f"  [....] Polling... attempt {attempt + 1}/{METADATA_MAX_POLLS} "
-                  f"(status={state}, elapsed={elapsed:.0f}s)")
-        time.sleep(METADATA_POLL_INTERVAL)
-    else:
-        _fail(
-            f"Retrieve did not complete within "
-            f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s. "
-            f"Consider increasing METADATA_MAX_POLLS in push_lineage.py."
-        )
-        sys.exit(1)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as batch_zf:
+            for name in batch_zf.namelist():
+                if name.endswith("package.xml"):
+                    continue
+                combined_zip.writestr(name, batch_zf.read(name))
 
-    return zip_bytes
+    combined_zip.close()
+    total_elapsed = time.monotonic() - t0
+    _ok(f"All {len(names)} record(s) retrieved in {total_elapsed:.1f}s")
+    return combined_buf.getvalue()
 
 
 def check_zip_contents(zip_bytes):

--- a/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
+++ b/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Salesforce Data 360 — Diagnostic Script
+
+Validates that all Salesforce APIs used by the lineage push script are
+accessible and reports timing/volume data. No Monte Carlo credentials needed.
+
+Usage:
+  pip install requests python-dotenv defusedxml
+  python3 sf_diagnostic.py
+
+Required env vars (or set in .env):
+  SF_ORG_URL       — My Domain URL, e.g. https://mycompany.my.salesforce.com
+  SF_CLIENT_ID     — Connected app consumer key
+  SF_CLIENT_SECRET — Connected app consumer secret
+"""
+import base64
+import io
+import os
+import sys
+import time
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+import requests
+from dotenv import load_dotenv
+
+try:
+    import defusedxml.ElementTree as SafeET
+except ImportError as err:
+    sys.exit(
+        f"ERROR: defusedxml is not installed. Run: pip install defusedxml>=0.7.1\n  ({err})"
+    )
+
+load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+
+SF_API_VERSION = "62.0"
+METADATA_MAX_POLLS = 120
+METADATA_POLL_INTERVAL = 5.0
+
+SOAP_NS = {
+    "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
+    "met":     "http://soap.sforce.com/2006/04/metadata",
+}
+OSTM_NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
+
+_RETRIEVE_ENVELOPE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:met="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Header>
+    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
+  </soapenv:Header>
+  <soapenv:Body>
+    <met:retrieve>
+      <met:retrieveRequest>
+        <met:apiVersion>{api_version}</met:apiVersion>
+        <met:unpackaged>
+          <met:types>
+            <met:members>*</met:members>
+            <met:name>ObjectSourceTargetMap</met:name>
+          </met:types>
+        </met:unpackaged>
+      </met:retrieveRequest>
+    </met:retrieve>
+  </soapenv:Body>
+</soapenv:Envelope>"""
+
+_STATUS_ENVELOPE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:met="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Header>
+    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
+  </soapenv:Header>
+  <soapenv:Body>
+    <met:checkRetrieveStatus>
+      <met:asyncProcessId>{async_id}</met:asyncProcessId>
+      <met:includeZip>true</met:includeZip>
+    </met:checkRetrieveStatus>
+  </soapenv:Body>
+</soapenv:Envelope>"""
+
+
+def _sep(label=""):
+    width = 60
+    if label:
+        print(f"\n{'─' * 3} {label} {'─' * (width - len(label) - 5)}")
+    else:
+        print("─" * width)
+
+
+def _ok(msg):  print(f"  [OK]   {msg}")
+def _warn(msg): print(f"  [WARN] {msg}")
+def _fail(msg): print(f"  [FAIL] {msg}")
+
+
+def check_auth(instance_url, client_id, client_secret):
+    _sep("1. OAuth — client credentials")
+    t0 = time.monotonic()
+    resp = requests.post(
+        f"{instance_url}/services/oauth2/token",
+        data={"grant_type": "client_credentials", "client_id": client_id, "client_secret": client_secret},
+        timeout=30,
+    )
+    data = resp.json()
+    if "error" in data:
+        _fail(f"Auth failed: {data.get('error')} — {data.get('error_description')}")
+        sys.exit(1)
+    elapsed = time.monotonic() - t0
+    _ok(f"Authenticated in {elapsed:.1f}s")
+    _ok(f"Instance URL: {data.get('instance_url')}")
+    return data["access_token"]
+
+
+def check_data_spaces(instance_url, token):
+    _sep("2. Data Spaces — Dataspace SOQL query")
+    t0 = time.monotonic()
+    resp = requests.get(
+        f"{instance_url}/services/data/v{SF_API_VERSION}/query",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"q": "SELECT DataSpaceApiName FROM Dataspace"},
+        timeout=30,
+    )
+    elapsed = time.monotonic() - t0
+    if resp.status_code != 200:
+        _warn(f"Query returned HTTP {resp.status_code} in {elapsed:.1f}s — data spaces unavailable")
+        _warn("The script will fall back to 'default' as the data space name")
+        return []
+    records = resp.json().get("records", [])
+    spaces = [r["DataSpaceApiName"] for r in records if r.get("DataSpaceApiName")]
+    if not spaces:
+        _warn(f"Query succeeded but returned 0 data spaces in {elapsed:.1f}s")
+        _warn("The script will fall back to 'default' as the data space name")
+        return []
+    _ok(f"Found {len(spaces)} data space(s) in {elapsed:.1f}s")
+    for s in spaces:
+        _ok(f"  • {s}")
+    if len(spaces) > 1:
+        _warn(
+            "Multiple data spaces found. The lineage push script will use the data space "
+            "recorded in each ObjectSourceTargetMap XML record. If a record has no <dataSpace> "
+            "field, it will fall back to the first data space returned here."
+        )
+    return spaces
+
+
+def check_metadata_retrieve(instance_url, token):
+    _sep("3. SOAP Metadata API — ObjectSourceTargetMap retrieve")
+
+    # Submit retrieve job
+    t0 = time.monotonic()
+    envelope = _RETRIEVE_ENVELOPE.format(
+        session_id=escape(token), api_version=escape(SF_API_VERSION)
+    )
+    url = f"{instance_url}/services/Soap/m/{SF_API_VERSION}"
+    resp = requests.post(
+        url,
+        data=envelope.encode("utf-8"),
+        headers={"Content-Type": "text/xml", "SOAPAction": "retrieve"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    root = SafeET.fromstring(resp.text)
+
+    fault = root.find(".//soapenv:Fault", SOAP_NS)
+    if fault is not None:
+        code = fault.findtext("faultcode", default="unknown")
+        msg  = fault.findtext("faultstring", default="no detail")
+        _fail(f"SOAP fault [{code}]: {msg}")
+        sys.exit(1)
+
+    async_id_el = root.find(".//met:id", SOAP_NS)
+    if async_id_el is None:
+        _fail("No async job ID returned from retrieve request")
+        sys.exit(1)
+
+    async_id = async_id_el.text
+    _ok(f"Retrieve job submitted (id={async_id})")
+
+    # Poll for completion
+    zip_bytes = None
+    for attempt in range(METADATA_MAX_POLLS):
+        status_body = _STATUS_ENVELOPE.format(
+            session_id=escape(token), async_id=escape(async_id)
+        )
+        status_resp = requests.post(
+            url,
+            data=status_body.encode("utf-8"),
+            headers={"Content-Type": "text/xml", "SOAPAction": "checkRetrieveStatus"},
+            timeout=60,
+        )
+        status_resp.raise_for_status()
+        status_root = SafeET.fromstring(status_resp.text)
+
+        done_el  = status_root.find(".//met:done",   SOAP_NS)
+        state_el = status_root.find(".//met:status", SOAP_NS)
+        state    = state_el.text if state_el is not None else "unknown"
+
+        if done_el is not None and done_el.text == "true":
+            if state == "Failed":
+                err_code = status_root.findtext(".//met:errorStatusCode", default="", namespaces=SOAP_NS)
+                err_msg  = status_root.findtext(".//met:errorMessage",    default="", namespaces=SOAP_NS)
+                _fail(f"Retrieve job failed [{err_code}]: {err_msg}")
+                sys.exit(1)
+            zip_el = status_root.find(".//met:zipFile", SOAP_NS)
+            if zip_el is None or not zip_el.text:
+                _fail("Retrieve completed but ZIP payload is empty")
+                sys.exit(1)
+            elapsed = time.monotonic() - t0
+            _ok(f"Retrieve completed after {attempt + 1} poll(s) ({elapsed:.1f}s)")
+            zip_bytes = base64.b64decode(zip_el.text)
+            break
+
+        if attempt % 5 == 0:
+            elapsed = time.monotonic() - t0
+            print(f"  [....] Polling... attempt {attempt + 1}/{METADATA_MAX_POLLS} "
+                  f"(status={state}, elapsed={elapsed:.0f}s)")
+        time.sleep(METADATA_POLL_INTERVAL)
+    else:
+        _fail(
+            f"Retrieve did not complete within "
+            f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s. "
+            f"Consider increasing METADATA_MAX_POLLS in push_lineage.py."
+        )
+        sys.exit(1)
+
+    return zip_bytes
+
+
+def check_zip_contents(zip_bytes):
+    _sep("4. ObjectSourceTargetMap — parse DLO→DMO edges")
+    zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    all_names = zf.namelist()
+    xml_files = [n for n in all_names if n.endswith(".objectSourceTargetMap")]
+    _ok(f"ZIP contains {len(all_names)} file(s) total")
+    _ok(f"ObjectSourceTargetMap records: {len(xml_files)}")
+
+    if not xml_files:
+        _warn("No .objectSourceTargetMap files found in ZIP")
+        _warn("Files present:")
+        for n in all_names[:20]:
+            _warn(f"  {n}")
+        return
+
+    edges = []
+    no_dataspace = 0
+    data_spaces_seen = set()
+
+    for name in xml_files:
+        with zf.open(name) as f:
+            try:
+                root = SafeET.parse(f).getroot()
+            except ET.ParseError:
+                continue
+        source = root.findtext("sf:sourceObjectName", namespaces=OSTM_NS)
+        target = root.findtext("sf:targetObjectName", namespaces=OSTM_NS)
+        if not source or not target:
+            continue
+        if source.endswith("__dll") and target.endswith("__dlm"):
+            ds = root.findtext("sf:dataSpace", namespaces=OSTM_NS)
+            if ds:
+                data_spaces_seen.add(ds)
+            else:
+                no_dataspace += 1
+            edges.append((source, target, ds or "(none in XML)"))
+
+    _ok(f"DLO→DMO edges found: {len(edges)}")
+
+    if data_spaces_seen:
+        _ok(f"Data spaces referenced in XML: {sorted(data_spaces_seen)}")
+    if no_dataspace:
+        _warn(
+            f"{no_dataspace}/{len(edges)} edges have no <dataSpace> field in XML. "
+            "The script will fall back to the value from the Dataspace SOQL query."
+        )
+
+    print()
+    print("  Edge list:")
+    for source, target, ds in edges:
+        print(f"    [{ds}] {source} → {target}")
+
+
+def main():
+    print("=" * 60)
+    print("  Salesforce Data 360 — Lineage Push Diagnostic")
+    print("=" * 60)
+
+    instance_url  = os.environ.get("SF_ORG_URL", "").rstrip("/")
+    client_id     = os.environ.get("SF_CLIENT_ID", "")
+    client_secret = os.environ.get("SF_CLIENT_SECRET", "")
+
+    missing = [n for n, v in [("SF_ORG_URL", instance_url), ("SF_CLIENT_ID", client_id), ("SF_CLIENT_SECRET", client_secret)] if not v]
+    if missing:
+        print(f"\n[FAIL] Missing required env vars: {', '.join(missing)}")
+        print("       Set them in a .env file or export them before running.")
+        sys.exit(1)
+
+    token = check_auth(instance_url, client_id, client_secret)
+    check_data_spaces(instance_url, token)
+    zip_bytes = check_metadata_retrieve(instance_url, token)
+    check_zip_contents(zip_bytes)
+
+    _sep()
+    print("  Diagnostic complete — all Salesforce APIs accessible.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `examples/push-ingestion/salesforce-data-cloud/` — a production-ready Python push-ingestion example that retrieves Salesforce Data 360 `ObjectSourceTargetMap` metadata (DLO→DMO mappings), validates assets against the Monte Carlo catalog, and pushes lineage via pycarlo's `IngestionService`
- **Live-tested**: 19 DLO→DMO edges pushed successfully against a real Salesforce org + Monte Carlo account
- Supersedes PR #60 with all review feedback applied

## Changes from PR #60

**Federico's review (service-class restructure):**
- `SalesforceDataCloudService` — encapsulates `authenticate`, `get_dataspaces`, `fetch_metadata`, `parse_edges`; HTTP methods decorated with `@_retrying`
- `SalesforceDataCloudLineageService` — encapsulates `_gql`, `_fetch_mc_catalog`, `validate_edges`, `push_edges`; HTTP methods decorated with `@_retrying`
- `_http` utility with manual retry loop removed; replaced by `tenacity` `@_retrying` decorator on individual methods

**Copilot review (8 items):**
- SSRF: `socket.getaddrinfo` DNS resolution + explicit `localhost` block + `is_reserved`/`is_multicast` checks
- `invocation_ids` None filter before `join()` in final summary log
- `_resolve_catalog` now accepts `preferred_data_space`; per-edge resolution in `validate_edges`
- ZIP filter restricted to `.objectSourceTargetMap` only; `-meta.xml` sidecars skipped at DEBUG
- pycarlo `Session` explicit `endpoint=MC_INGEST_URL`
- README: `cd salesforce-data-cloud` (correct directory name)
- TROUBLESHOOTING: dry-run description corrected (no per-request logging claim)
- `sf_diagnostic.py`: switched to `defusedxml` for SOAP XML parsing

## Test plan

- [ ] `python3 push_lineage.py --dry-run` completes without error
- [ ] `python3 push_lineage.py` pushes edges and prints `invocation_ids` in final log line
- [ ] `python3 sf_diagnostic.py` validates Salesforce connectivity independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)