### PR TITLE
feat(salesforce-data-cloud): add Source→DLO external lineage push + run_all wrapper

### DIFF
--- a/examples/push-ingestion/salesforce-data-cloud/.env.example
+++ b/examples/push-ingestion/salesforce-data-cloud/.env.example
@@ -1,5 +1,10 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Data 360 Lineage Push (DLO→DMO + DMO→CIO) — Environment Variables
+# Data 360 Lineage Push — Environment Variables
+#
+# Used by all three scripts in this directory:
+#   run_all.py               — full end-to-end push (recommended)
+#   push_external_lineage.py — Source (CRM/Snowflake) → DLO only
+#   push_lineage.py          — DLO → DMO → CIO only
 #
 # Copy this file to .env and fill in your values:
 #   cp .env.example .env
@@ -9,6 +14,7 @@
 
 
 # ── Salesforce credentials ────────────────────────────────────────────────────
+# Shared by all three scripts.
 
 # Your org's My Domain URL. Must start with https://.
 # Find it in Salesforce Setup → My Domain.
@@ -23,7 +29,8 @@ SF_CLIENT_SECRET=
 
 
 # ── Monte Carlo — Ingestion key ───────────────────────────────────────────────
-# Used to push lineage via the Ingest API (/ingest/v1/lineage).
+# Required by push_lineage.py (DLO→DMO→CIO push via Ingest API).
+# Not needed by push_external_lineage.py, which uses GraphQL directly.
 #
 # Create with the Monte Carlo CLI:
 #   montecarlo integrations create-key --scope Ingestion --description "Data 360 lineage push"
@@ -33,7 +40,8 @@ MCD_INGEST_TOKEN=
 
 
 # ── Monte Carlo — Personal API key ───────────────────────────────────────────
-# Used for catalog validation via the GraphQL API.
+# Required by both push_external_lineage.py and push_lineage.py.
+# Used for catalog lookup and lineage push via GraphQL.
 # This is a DIFFERENT key from the Ingestion key above.
 #
 # Create in the Monte Carlo UI: Settings → API Keys → Create Key.
@@ -44,16 +52,56 @@ MCD_TOKEN=
 
 
 # ── Monte Carlo — Data Cloud warehouse UUID ───────────────────────────────────
-# The UUID of your Salesforce Data Cloud warehouse in Monte Carlo.
+# Required by both scripts. The UUID of your Salesforce Data Cloud warehouse
+# in Monte Carlo.
 # Find it in Monte Carlo UI: Settings → Integrations → your Data Cloud connection.
 #
+# push_lineage.py          reads this as MCD_RESOURCE_UUID
+# push_external_lineage.py reads this as MCD_DC_WAREHOUSE_UUID (falls back to MCD_RESOURCE_UUID)
+# Setting MCD_RESOURCE_UUID here covers both scripts from a single .env entry.
+#
 MCD_RESOURCE_UUID=
+
+
+# ── Monte Carlo — Salesforce CRM warehouse UUID ───────────────────────────────
+# Required by push_external_lineage.py for CRM→DLO edges.
+# Find it in Monte Carlo UI: Settings → Integrations → your Salesforce CRM connection.
+# Leave blank to skip CRM→DLO lineage.
+#
+# MCD_CRM_WAREHOUSE_UUID=
+
+
+# ── Monte Carlo — CRM multi-org map ──────────────────────────────────────────
+# Use when the customer has more than one Salesforce CRM org connected to MC.
+# Format: comma-separated DataConnectorId=warehouse_uuid pairs.
+# Run push_external_lineage.py --discover with LOG_LEVEL=DEBUG to see connector IDs.
+# When set, takes precedence over MCD_CRM_WAREHOUSE_UUID for linked-org streams.
+#
+# MCD_CRM_WAREHOUSE_MAP=0XA000000000001=<prod-crm-uuid>,0XA000000000002=<sandbox-crm-uuid>
+
+
+# ── Monte Carlo — Snowflake warehouse UUID ────────────────────────────────────
+# Required by push_external_lineage.py for Snowflake→DLO edges.
+# Find it in Monte Carlo UI: Settings → Integrations → your Snowflake connection.
+# Leave blank to skip Snowflake→DLO lineage.
+#
+# MCD_SNOWFLAKE_WAREHOUSE_UUID=
+
+
+# ── Monte Carlo — Snowflake multi-warehouse map ───────────────────────────────
+# Use when you have more than one Snowflake account connected to MC.
+# Format: comma-separated account_identifier=warehouse_uuid pairs.
+# The account identifier is the hostname prefix of the Snowflake account URL:
+#   https://HDB68299.us-west-2.snowflakecomputing.com → hdb68299.us-west-2
+# When set, takes precedence over MCD_SNOWFLAKE_WAREHOUSE_UUID.
+#
+# MCD_SNOWFLAKE_WAREHOUSE_MAP=abc12345.us-east-1=<prod-uuid>,xyz99999.eu-west-1=<sandbox-uuid>
 
 
 # ── Optional: logging ─────────────────────────────────────────────────────────
 
 # Log verbosity. Options: DEBUG, INFO, WARNING, ERROR. Default: INFO.
-# Use DEBUG to see every HTTP request and poll attempt when troubleshooting.
+# Use DEBUG to see every HTTP request and resolution decision when troubleshooting.
 # LOG_LEVEL=INFO
 
 # Log format. Set to "json" for structured output (Splunk, Datadog, CloudWatch, etc.).
@@ -61,7 +109,7 @@ MCD_RESOURCE_UUID=
 # LOG_FORMAT=json
 
 
-# ── Optional: tuning ──────────────────────────────────────────────────────────
+# ── Optional: push_lineage.py tuning ──────────────────────────────────────────
 
 # Number of lineage edges per Monte Carlo push batch. Default: 500.
 # Reduce if you hit request size limits.
@@ -70,7 +118,6 @@ MCD_RESOURCE_UUID=
 # Maximum number of SOAP polling attempts when retrieving Salesforce metadata.
 # Default: 120. Each poll waits METADATA_POLL_INTERVAL seconds, so the default
 # timeout is 120 × 5 = 600 seconds (10 minutes). Increase for very large orgs.
-# If the script times out at Step 3, double METADATA_MAX_POLLS and retry.
 # METADATA_MAX_POLLS=120
 
 # Seconds between SOAP polls. Default: 5.
@@ -80,17 +127,6 @@ MCD_RESOURCE_UUID=
 # Reduce if the Metadata API returns timeout or "too large" errors on Step 3.
 # METADATA_BATCH_SIZE=10
 
-
-# ── Optional: CLI flags (passed at runtime, not in .env) ─────────────────────
-# --dry-run       Run all steps but skip the final MC push. Safe to use at any time.
-# --skip-cio      Push DLO→DMO lineage only; skip CIO fetch and DMO→CIO push.
-#
-# Example: python3 push_lineage.py --dry-run
-#          python3 push_lineage.py --skip-cio
-
-
-# ── Optional: data space fallback ─────────────────────────────────────────────
-# Used when a DLO record's data space cannot be resolved from the XML metadata
-# or the data-streams API. Default: "default".
-# Set this if your org uses a different primary data space name.
+# Data space fallback — used when a DLO record's data space cannot be resolved.
+# Default: "default". Set this if your org uses a different primary data space name.
 # SF_DEFAULT_DATA_SPACE=default

--- a/examples/push-ingestion/salesforce-data-cloud/.env.example
+++ b/examples/push-ingestion/salesforce-data-cloud/.env.example
@@ -29,8 +29,11 @@ SF_CLIENT_SECRET=
 
 
 # ── Monte Carlo — Ingestion key ───────────────────────────────────────────────
-# Required by push_lineage.py (DLO→DMO→CIO push via Ingest API).
-# Not needed by push_external_lineage.py, which uses GraphQL directly.
+# Required by both push_lineage.py (DLO→DMO→CIO push) and push_external_lineage.py
+# (cross-warehouse lineage push via Ingest API).
+#
+# The Ingestion key must be authorized for every warehouse referenced — both source
+# (CRM/Snowflake) and destination (Data Cloud).
 #
 # Create with the Monte Carlo CLI:
 #   montecarlo integrations create-key --scope Ingestion --description "Data 360 lineage push"
@@ -41,7 +44,7 @@ MCD_INGEST_TOKEN=
 
 # ── Monte Carlo — Personal API key ───────────────────────────────────────────
 # Required by both push_external_lineage.py and push_lineage.py.
-# Used for catalog lookup and lineage push via GraphQL.
+# Used for catalog lookup (getTables GraphQL query) only — not for the lineage push.
 # This is a DIFFERENT key from the Ingestion key above.
 #
 # Create in the Monte Carlo UI: Settings → API Keys → Create Key.

--- a/examples/push-ingestion/salesforce-data-cloud/.env.example
+++ b/examples/push-ingestion/salesforce-data-cloud/.env.example
@@ -77,7 +77,7 @@ MCD_RESOURCE_UUID=
 # ── Monte Carlo — CRM multi-org map ──────────────────────────────────────────
 # Use when the customer has more than one Salesforce CRM org connected to MC.
 # Format: comma-separated DataConnectorId=warehouse_uuid pairs.
-# Run push_external_lineage.py --discover with LOG_LEVEL=DEBUG to see connector IDs.
+# Run push_external_lineage.py --dry-run with LOG_LEVEL=DEBUG to see connector IDs.
 # When set, takes precedence over MCD_CRM_WAREHOUSE_UUID for linked-org streams.
 #
 # MCD_CRM_WAREHOUSE_MAP=0XA000000000001=<prod-crm-uuid>,0XA000000000002=<sandbox-crm-uuid>

--- a/examples/push-ingestion/salesforce-data-cloud/.gitignore
+++ b/examples/push-ingestion/salesforce-data-cloud/.gitignore
@@ -42,8 +42,10 @@ $RECYCLE.BIN/
 # Local environment variables
 .env
 
-# Failed-edge retry files from push_lineage.py
+# Runtime output files from push_lineage.py and push_external_lineage.py
 failed_edges_*.json
+skipped_streams_*.json
+discover_*.json
 
 # Python Salesforce Functions
 **/__pycache__/

--- a/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
+++ b/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
@@ -288,6 +288,40 @@ edge.
 
 ---
 
+## Required Salesforce Permissions
+
+The connected app's run-as user must have the following permissions. Missing any of
+these is the most common cause of `INSUFFICIENT_ACCESS` and `403` errors.
+
+### DLO→DMO lineage (Steps 1–4)
+
+**Run-as user profile permissions:**
+- `API Enabled`
+- `Modify Metadata Through Metadata API Functions` *(or `Modify All Data`)*
+
+These are set in Salesforce Setup → Users → your run-as user → Profile → Edit.
+
+### DMO→CIO lineage (Steps 5–8)
+
+In addition to the profile permissions above:
+
+**Run-as user permission set:**
+- `Data Cloud Admin` **or** `Data Cloud User`
+
+Assign in Salesforce Setup → Users → your run-as user → Permission Set Assignments.
+
+**Connected app OAuth scopes** (Salesforce Setup → App Manager → your app → Edit):
+- `Access and manage your data (api)`
+- `Perform requests on your behalf at any time (refresh_token, offline_access)`
+
+> The CIO endpoint (`/services/data/v62.0/ssot/calculated-insights`) is a Data Cloud
+> REST API that is separate from the Metadata API. Profile permissions alone do not
+> grant access to it — the `Data Cloud Admin` or `Data Cloud User` permission set is
+> required. If you only need DLO→DMO lineage, use `--skip-cio` to bypass Steps 5–8
+> entirely and the permission set is not needed.
+
+---
+
 ## Common Setup Checklist
 
 If you're unsure where a problem is, work through this list:

--- a/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
@@ -3,7 +3,7 @@
 Data 360 External Source → DLO Lineage Push
 
 Pushes CRM→DLO and Snowflake→DLO lineage edges into Monte Carlo using the
-createOrUpdateLineageEdge GraphQL mutation so that external source tables
+Push Ingest API cross-warehouse lineage feature so that external source tables
 appear as trusted lineage upstream of Data 360 Data Lake Objects.
 
 Only sources that already exist as first-class objects in a Monte Carlo
@@ -15,7 +15,7 @@ Pipeline:
   2. Fetch all Data Streams from the Salesforce Connect REST API
   3. Fetch MC catalog tables for Data Cloud, CRM, and/or Snowflake warehouses
   4. Match each stream's source table and DLO to MC catalog entries
-  5. Push lineage edges via createOrUpdateLineageEdge GraphQL mutation
+  5. Push lineage edges via Ingest API cross-warehouse lineage
 
 Usage:
   python3 push_external_lineage.py --dry-run
@@ -24,13 +24,10 @@ Usage:
 
 Required env vars (see .env.example):
   SF_ORG_URL, SF_CLIENT_ID, SF_CLIENT_SECRET
-  MCD_ID, MCD_TOKEN              — Personal API key (catalog lookup + lineage push)
-                                   Note: this integration uses a single Personal API key for
-                                   both catalog lookups (getTables) and lineage push
-                                   (createOrUpdateLineageEdge). No separate Ingestion key is
-                                   needed; invocation_ids are a Pandora Ingestion-API concept
-                                   and do not apply to the GraphQL mutation path used here.
-  MCD_DC_WAREHOUSE_UUID          — Monte Carlo Data Cloud warehouse UUID
+  MCD_INGEST_ID, MCD_INGEST_TOKEN — Ingestion key for the push (must be authorized for ALL
+                                    referenced warehouses: Data Cloud + CRM and/or Snowflake)
+  MCD_ID, MCD_TOKEN               — Personal API key for catalog lookup only
+  MCD_DC_WAREHOUSE_UUID           — Monte Carlo Data Cloud warehouse UUID
 
 Optional env vars:
   MCD_CRM_WAREHOUSE_UUID         — MC CRM warehouse UUID (single-org fallback)
@@ -71,6 +68,16 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
+
+try:
+    from pycarlo.core import Client, Session
+    from pycarlo.features.ingestion import IngestionService
+    from pycarlo.features.ingestion.models import LineageAssetRef, LineageEvent
+except ImportError as err:
+    import sys as _sys
+    _sys.exit(
+        f"ERROR: pycarlo is not installed. Run: pip install pycarlo>=0.12.478\n  ({err})"
+    )
 
 load_dotenv(dotenv_path=Path(__file__).parent / ".env")
 
@@ -131,6 +138,11 @@ _SENSITIVE_PARAM_NAMES = frozenset({
     "bearertoken", "bearer_token",
     "oauthtoken", "oauth_token",
 })
+
+# MC resource_type values for cross-warehouse lineage push
+_CRM_RESOURCE_TYPE       = "salesforce"
+_SNOWFLAKE_RESOURCE_TYPE = "snowflake"
+_DC_RESOURCE_TYPE        = "salesforce-data-cloud"
 
 
 # ── Logging ───────────────────────────────────────────────────────────────────
@@ -334,6 +346,15 @@ def _parse_warehouse_map(raw: str) -> dict:
     return result
 
 
+def _parse_full_table_id(fid: str) -> tuple:
+    """Parse fullTableId 'database:schema.name' → (database, schema, name)."""
+    db, _, rest = fid.partition(":")
+    if not rest:
+        rest, db = db, ""
+    schema, _, name = rest.rpartition(".")
+    return db, schema, name
+
+
 def _http(
     method: str,
     url: str,
@@ -438,8 +459,8 @@ def _gql(query: str, key_id: str, key_secret: str, variables: Optional[dict] = N
     if "errors" in body:
         msgs = [_sanitize_for_log(e.get("message", str(e))) for e in body["errors"]]
         hint = (
-            " (source node does not exist in MC catalog — "
-            "register it via Push Ingest API before linking)"
+            " (warehouse UUID may be wrong or the table doesn't exist in MC — "
+            "verify MCD_DC_WAREHOUSE_UUID/MCD_CRM_WAREHOUSE_UUID/MCD_SNOWFLAKE_WAREHOUSE_UUID)"
             if any("not found" in m.lower() for m in msgs)
             else " (verify MCD_ID/MCD_TOKEN are a Personal API key, not an Ingestion key)"
         )
@@ -1379,24 +1400,9 @@ def _run_discover(streams: list, run_id: str, instance_url: str) -> None:
     )
 
 
-# ── Step 4: GraphQL mutations ─────────────────────────────────────────────────
-_CREATE_EDGE_MUTATION = """
-mutation CreateEdge($source: NodeInput!, $destination: NodeInput!) {
-  createOrUpdateLineageEdge(source: $source, destination: $destination) {
-    edge {
-      source { mcon objectType }
-      destination { mcon objectType }
-    }
-  }
-}
-"""
+# ── Step 5: Push via Ingest API (cross-warehouse) ─────────────────────────────
 
-
-def _is_push_retryable(exc: BaseException) -> bool:
-    # GraphQL application errors (MCGraphQLError) are permanent — never retry.
-    if isinstance(exc, MCGraphQLError):
-        return False
-    # Suppress retry on HTTP 4xx (won't resolve on retry).
+def _is_ingest_retryable(exc: BaseException) -> bool:
     resp = getattr(exc, "response", None)
     if resp is not None and 400 <= resp.status_code < 500:
         return False
@@ -1406,74 +1412,96 @@ def _is_push_retryable(exc: BaseException) -> bool:
 @retry(
     stop=stop_after_attempt(4),
     wait=wait_exponential(multiplier=2, min=2, max=60),
-    retry=retry_if_exception(_is_push_retryable),
+    retry=retry_if_exception(_is_ingest_retryable),
     reraise=True,
 )
-def _push_one_edge(
-    source_node: dict,
-    dest_node: dict,
-    key_id: str,
-    key_secret: str,
-) -> dict:
-    return _gql(
-        _CREATE_EDGE_MUTATION,
-        key_id,
-        key_secret,
-        variables={"source": source_node, "destination": dest_node},
-    )
+def _send_batch(svc: IngestionService, events: list) -> dict:
+    return svc.send_lineage(events=events)
 
 
 def push_edges(
     edges: list,
-    key_id: str,
-    key_secret: str,
+    ingest_key_id: str,
+    ingest_key_secret: str,
     run_id: str,
+    batch_size: int = 500,
     shutdown_flag: Optional[threading.Event] = None,
 ) -> int:
     """
-    Push all resolved edges one at a time via createOrUpdateLineageEdge mutation.
-    The mutation is idempotent — re-running is safe.
+    Push resolved edges via Ingest API cross-warehouse lineage.
+    Each edge specifies resource_uuid + resource_type per asset — no top-level resource.
+    The push is idempotent — re-running is safe.
     Returns count of successfully pushed edges.
-    Saves any failed edges to a local JSON file for retry.
-    Stops cleanly if shutdown_flag is set (SIGTERM).
     """
     t0 = time.monotonic()
-    log.info("Step 5: Pushing %d edge(s) via GraphQL mutation", len(edges))
+    log.info("Step 5: Pushing %d edge(s) via Ingest API (cross-warehouse)", len(edges))
+
+    svc = IngestionService(mc_client=Client(session=Session(
+        mcd_id=ingest_key_id,
+        mcd_token=ingest_key_secret,
+        scope="Ingestion",
+    )))
+
+    _resource_type_map = {
+        _CONNECTOR_SFDC:      _CRM_RESOURCE_TYPE,
+        _CONNECTOR_SNOWFLAKE: _SNOWFLAKE_RESOURCE_TYPE,
+    }
+
     pushed = 0
     failures: list = []
+    batches = [edges[i:i + batch_size] for i in range(0, len(edges), batch_size)]
+    invocation_ids: list = []
 
-    for i, edge in enumerate(edges, 1):
+    for batch_idx, batch in enumerate(batches, 1):
         if shutdown_flag is not None and shutdown_flag.is_set():
             log.warning(
-                "SIGTERM received — stopping push after %d/%d edges. "
-                "Partial results have been written to Monte Carlo. Re-run is safe (idempotent).",
-                i - 1, len(edges),
+                "SIGTERM received — stopping push after batch %d/%d. "
+                "Partial results written to Monte Carlo. Re-run is safe (idempotent).",
+                batch_idx - 1, len(batches),
             )
             break
-        source_node = {
-            "objectType": "TABLE",
-            "objectId":   edge["source_full_id"],
-            "resourceId": edge["source_warehouse"],
-        }
-        dest_node = {
-            "objectType": "TABLE",
-            "objectId":   edge["dest_full_id"],
-            "resourceId": edge["dest_warehouse"],
-        }
+
+        events = []
+        for e in batch:
+            src_db, src_schema, src_name = _parse_full_table_id(e["source_full_id"])
+            dst_db, dst_schema, dst_name = _parse_full_table_id(e["dest_full_id"])
+            src_resource_type = _resource_type_map.get(
+                e["connector_type"], e["connector_type"].lower()
+            )
+            events.append(LineageEvent(
+                destination=LineageAssetRef(
+                    type="TABLE",
+                    database=dst_db,
+                    schema=dst_schema,
+                    name=dst_name,
+                    resource_uuid=e["dest_warehouse"],
+                    resource_type=_DC_RESOURCE_TYPE,
+                ),
+                sources=[LineageAssetRef(
+                    type="TABLE",
+                    database=src_db,
+                    schema=src_schema,
+                    name=src_name,
+                    resource_uuid=e["source_warehouse"],
+                    resource_type=src_resource_type,
+                )],
+            ))
+
         try:
-            result = _push_one_edge(source_node, dest_node, key_id, key_secret)
-            pushed += 1
-            edge_result = (result.get("createOrUpdateLineageEdge") or {}).get("edge") or {}
-            src_mcon = (edge_result.get("source") or {}).get("mcon", "?")
-            dst_mcon = (edge_result.get("destination") or {}).get("mcon", "?")
-            log.info("  [%d/%d] Pushed: %s → %s", i, len(edges), edge["source_label"], edge["dlo_name"])
-            log.debug("    src_mcon=%s  dst_mcon=%s", src_mcon, dst_mcon)
+            result = _send_batch(svc, events)
+            inv_id = (result or {}).get("invocation_id", "?")
+            invocation_ids.append(inv_id)
+            log.info(
+                "  Batch %d/%d: %d edge(s) pushed — invocation_id=%s",
+                batch_idx, len(batches), len(batch), inv_id,
+            )
+            pushed += len(batch)
         except Exception as exc:
             log.error(
-                "  [%d/%d] Failed to push %s → %s: %s",
-                i, len(edges), edge["source_label"], edge["dlo_name"], exc,
+                "  Batch %d/%d failed (%d edge(s)): %s",
+                batch_idx, len(batches), len(batch), exc,
             )
-            failures.append(edge)
+            failures.extend(batch)
 
     if failures:
         try:
@@ -1489,8 +1517,8 @@ def push_edges(
                 for e in failures
             ]
             log.error(
-                "%d edge(s) failed to push and the failed-edge file could not be written (%s). "
-                "Failed edges (connector_type, dlo_name): %s",
+                "%d edge(s) failed and the failed-edge file could not be written (%s). "
+                "Failed edges: %s",
                 len(failures), exc, json.dumps(summary)[:2000],
             )
 
@@ -1533,9 +1561,17 @@ class SalesforceService:
 
 
 class MCLineageService:
-    def __init__(self, key_id: str, key_secret: str) -> None:
+    def __init__(
+        self,
+        key_id: str,
+        key_secret: str,
+        ingest_key_id: str,
+        ingest_key_secret: str,
+    ) -> None:
         self.key_id = key_id
         self.key_secret = key_secret
+        self.ingest_key_id = ingest_key_id
+        self.ingest_key_secret = ingest_key_secret
 
     def fetch_catalog(self, warehouse_uuid: str, label: str) -> _CatalogIndex:
         return _fetch_catalog(warehouse_uuid, self.key_id, self.key_secret, label)
@@ -1544,9 +1580,12 @@ class MCLineageService:
         self,
         edges: list,
         run_id: str,
+        batch_size: int = 500,
         shutdown_flag: Optional[threading.Event] = None,
     ) -> int:
-        return push_edges(edges, self.key_id, self.key_secret, run_id, shutdown_flag)
+        return push_edges(
+            edges, self.ingest_key_id, self.ingest_key_secret, run_id, batch_size, shutdown_flag
+        )
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -1597,6 +1636,8 @@ def main() -> None:
     if not args.discover:
         mcd_id    = _require("MCD_ID")
         mcd_token = _require("MCD_TOKEN")
+        mcd_ingest_id    = _require("MCD_INGEST_ID")
+        mcd_ingest_token = _require("MCD_INGEST_TOKEN")
         # Accept MCD_RESOURCE_UUID as an alias for MCD_DC_WAREHOUSE_UUID so that
         # users running both scripts from the same .env only need to set one variable.
         dc_warehouse_uuid = (
@@ -1693,7 +1734,7 @@ def main() -> None:
             log.warning("No data streams returned from Salesforce — nothing to push.")
             sys.exit(0)
 
-        mc_svc = MCLineageService(mcd_id, mcd_token)
+        mc_svc = MCLineageService(mcd_id, mcd_token, mcd_ingest_id, mcd_ingest_token)
 
         connector_types_present = {
             (s.get("connectorInfo") or {}).get("connectorType", "") for s in streams
@@ -1849,8 +1890,9 @@ def main() -> None:
         )
         sys.exit(0)
 
+    _batch_size = int(os.environ.get("INGEST_BATCH_SIZE", "500"))
     try:
-        pushed_count = mc_svc.push_edges(edges, run_id, _shutdown_requested)
+        pushed_count = mc_svc.push_edges(edges, run_id, _batch_size, _shutdown_requested)
     except KeyboardInterrupt:
         log.warning("Interrupted during push — partial results may have been written to Monte Carlo.")
         sys.exit(1)

--- a/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
@@ -26,25 +26,25 @@ Required env vars (see .env.example):
   SF_ORG_URL, SF_CLIENT_ID, SF_CLIENT_SECRET
   MCD_INGEST_ID, MCD_INGEST_TOKEN — Ingestion key for the push (must be authorized for ALL
                                     referenced warehouses: Data Cloud + CRM and/or Snowflake)
-  MCD_ID, MCD_TOKEN               — Personal API key for catalog lookup only
-  MCD_DC_WAREHOUSE_UUID           — Monte Carlo Data Cloud warehouse UUID
+  MCD_ID, MCD_TOKEN               — Personal API key for catalog lookup and warehouse discovery
 
-Optional env vars:
-  MCD_CRM_WAREHOUSE_UUID         — MC CRM warehouse UUID (single-org fallback)
+Warehouse UUIDs are auto-discovered from Monte Carlo using the Salesforce org domain and
+Snowflake account identifiers. No manual UUID configuration is needed for most deployments.
+
+Optional env var overrides (rarely needed):
+  MCD_DC_WAREHOUSE_UUID / MCD_RESOURCE_UUID — Override auto-discovered Data Cloud warehouse UUID
+  MCD_CRM_WAREHOUSE_UUID         — Override auto-discovered CRM warehouse UUID
   MCD_CRM_WAREHOUSE_MAP          — Multi-org CRM map: "connector_id1=uuid1,connector_id2=uuid2"
-                                   connector_id is the DataConnectorId from DataStreamDefinition.
-                                   Used for linked/external CRM org streams; native same-org
-                                   streams fall back to MCD_CRM_WAREHOUSE_UUID.
-                                   Takes precedence over MCD_CRM_WAREHOUSE_UUID when set.
-  MCD_SNOWFLAKE_WAREHOUSE_UUID   — MC Snowflake warehouse UUID (single-warehouse fallback)
+                                   Only needed when multiple CRM orgs feed the same Data Cloud org.
+  MCD_SNOWFLAKE_WAREHOUSE_UUID   — Override auto-discovered Snowflake warehouse UUID
   MCD_SNOWFLAKE_WAREHOUSE_MAP    — Multi-warehouse map: "account_id=uuid,account_id2=uuid2"
-                                   account_id is the Snowflake account identifier extracted from
-                                   the accountUrl in MktDataConnection (e.g. "hdb68299.us-west-2")
-                                   Takes precedence over MCD_SNOWFLAKE_WAREHOUSE_UUID when set.
+                                   Only needed when multiple Snowflake accounts are in use and
+                                   auto-discovery picks the wrong one.
   LOG_LEVEL                      — DEBUG/INFO/WARNING/ERROR (default: INFO)
   LOG_FORMAT                     — json for structured output (default: plain)
 """
 import argparse
+import concurrent.futures
 import ipaddress
 import json
 import logging
@@ -96,6 +96,10 @@ _MAX_PAGES = 500
 # from a malicious or misconfigured server sending a very large response body.
 _MAX_RESPONSE_BYTES = 50 * 1024 * 1024  # 50 MB
 
+# Warn if getWarehouses returns more than this many entries — suggests the account may have
+# more connections than a single unparameterised query can return.
+_MAX_WAREHOUSES_DISCOVERY = 200
+
 # Batch size for SOQL IN clauses — keeps each query well under URL and record-count limits.
 # Salesforce Tooling API returns at most 2000 records per response; batching at 200 keeps
 # each batch comfortably under that limit and avoids URL length errors at scale.
@@ -140,7 +144,7 @@ _SENSITIVE_PARAM_NAMES = frozenset({
 })
 
 # MC resource_type values for cross-warehouse lineage push
-_CRM_RESOURCE_TYPE       = "salesforce"
+_CRM_RESOURCE_TYPE       = "salesforce-crm"
 _SNOWFLAKE_RESOURCE_TYPE = "snowflake"
 _DC_RESOURCE_TYPE        = "salesforce-data-cloud"
 
@@ -297,6 +301,17 @@ def _validate_uuid(name: str, value: str) -> None:
         sys.exit(1)
 
 
+def _parse_positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    try:
+        val = int(raw)
+        if val < 1:
+            raise ValueError("must be >= 1")
+        return val
+    except ValueError as exc:
+        sys.exit(f"Invalid {name}={raw!r}: {exc}")
+
+
 def _extract_sf_account_identifier(account_url: str) -> str:
     """Extract lowercased account identifier from a Snowflake accountUrl.
 
@@ -419,6 +434,13 @@ def _http(
                 f"allow_redirects is False. Location: {location!r}"
             )
 
+        if len(resp.content) > _MAX_RESPONSE_BYTES:
+            raise RuntimeError(
+                f"Response body from {_log_url} is too large "
+                f"({len(resp.content):,} bytes > {_MAX_RESPONSE_BYTES:,} byte limit). "
+                "Refusing to parse."
+            )
+
         return resp
 
     raise RuntimeError("_http retry loop exhausted unexpectedly")
@@ -443,11 +465,6 @@ def _gql(query: str, key_id: str, key_secret: str, variables: Optional[dict] = N
         max_retries=0,  # retry responsibility delegated to tenacity at the push layer
     )
     resp.raise_for_status()
-    if len(resp.content) > _MAX_RESPONSE_BYTES:
-        raise RuntimeError(
-            f"MC GraphQL response body is too large ({len(resp.content):,} bytes > "
-            f"{_MAX_RESPONSE_BYTES:,} byte limit). Refusing to parse."
-        )
     try:
         body = resp.json()
     except ValueError as exc:
@@ -478,9 +495,12 @@ def _gql(query: str, key_id: str, key_secret: str, variables: Optional[dict] = N
 def get_sf_token(instance_url: str, client_id: str, client_secret: str) -> str:
     t0 = time.monotonic()
     log.info("Step 1: Authenticating with Salesforce (%s)", instance_url)
-    resp = _http(
-        "POST",
-        f"{instance_url}/services/oauth2/token",
+    token_url = f"{instance_url}/services/oauth2/token"
+    instance_host = (urlparse(instance_url).hostname or "").lower()
+    # Use allow_redirects=False so we can validate redirect destinations before following.
+    # We bypass _http here to intercept the raw 3xx response; the redirect GET goes through _http.
+    resp = requests.post(
+        token_url,
         data={
             "grant_type":    "client_credentials",
             "client_id":     client_id,
@@ -488,8 +508,36 @@ def get_sf_token(instance_url: str, client_id: str, client_secret: str) -> str:
         },
         verify=True,
         timeout=30,
-        allow_redirects=True,  # Salesforce may 302 on org migrations / MyDomain moves
+        allow_redirects=False,
     )
+    # MyDomain / org migration: 301/302/303 are safe (requests downgrades POST→GET, no body).
+    # 307/308 would re-POST the credentials body to the redirect target — reject them.
+    if 300 <= resp.status_code < 400:
+        if resp.status_code in (307, 308):
+            raise RuntimeError(
+                f"Salesforce OAuth returned {resp.status_code} — this redirect type preserves "
+                "the POST body, which would exfiltrate client_secret to the redirect target. "
+                "Update SF_ORG_URL to match your org's current MyDomain URL and re-run."
+            )
+        location = resp.headers.get("Location", "")
+        if not location:
+            raise RuntimeError(
+                f"Salesforce OAuth {resp.status_code} redirect has no Location header"
+            )
+        loc_parsed = urlparse(location)
+        # Compare hostname (not netloc) so an explicit :443 suffix doesn't cause a false-positive
+        if loc_parsed.scheme != "https" or (loc_parsed.hostname or "").lower() != instance_host.lower():
+            raise RuntimeError(
+                f"Salesforce OAuth redirect crosses origins "
+                f"(expected {instance_host!r}, got {loc_parsed.hostname!r}). "
+                "Update SF_ORG_URL to the correct MyDomain URL and re-run."
+            )
+        resp = _http("GET", location, verify=True, timeout=30)
+    if len(resp.content) > _MAX_RESPONSE_BYTES:
+        raise RuntimeError(
+            f"Salesforce OAuth response body too large "
+            f"({len(resp.content):,} bytes > {_MAX_RESPONSE_BYTES:,} byte limit)"
+        )
     try:
         data = resp.json()
     except ValueError:
@@ -537,7 +585,7 @@ def fetch_data_streams(instance_url: str, access_token: str) -> list:
                 "This likely indicates a Salesforce API bug or a runaway response."
             )
 
-        resp = _http("GET", url, headers=headers, verify=True, timeout=30, allow_redirects=True)
+        resp = _http("GET", url, headers=headers, verify=True, timeout=30)
         resp.raise_for_status()
         try:
             body = resp.json()
@@ -559,10 +607,10 @@ def fetch_data_streams(instance_url: str, access_token: str) -> list:
         # Construct and validate the next page URL before following it (SSRF guard)
         next_url = next_path if next_path.startswith("https://") else f"{instance_url}{next_path}"
         next_parsed = urlparse(next_url)
-        if next_parsed.scheme != "https" or next_parsed.netloc != instance_parsed.netloc:
+        if next_parsed.scheme != "https" or (next_parsed.hostname or "").lower() != (instance_parsed.hostname or "").lower():
             raise RuntimeError(
                 f"Salesforce nextPageUrl has unexpected origin (got: {next_url!r}, "
-                f"expected scheme=https host={instance_parsed.netloc}). Aborting to prevent SSRF."
+                f"expected scheme=https host={instance_parsed.hostname}). Aborting to prevent SSRF."
             )
         url = next_url
 
@@ -666,7 +714,6 @@ def fetch_connection_details(
                 headers=headers,
                 verify=True,
                 timeout=30,
-                allow_redirects=True,
             )
             resp.raise_for_status()
             try:
@@ -700,10 +747,10 @@ def fetch_connection_details(
             )
             next_parsed_t = urlparse(next_url)
             if (next_parsed_t.scheme != "https"
-                    or next_parsed_t.netloc != instance_parsed_tooling.netloc):
+                    or (next_parsed_t.hostname or "").lower() != (instance_parsed_tooling.hostname or "").lower()):
                 raise RuntimeError(
                     f"DataStreamDefinition nextRecordsUrl has unexpected origin "
-                    f"(got: {next_url!r}, expected host={instance_parsed_tooling.netloc}). "
+                    f"(got: {next_url!r}, expected host={instance_parsed_tooling.hostname}). "
                     "Aborting to prevent SSRF."
                 )
             tooling_url = next_url
@@ -715,35 +762,35 @@ def fetch_connection_details(
 
     log.info("  Found DataConnectorId for %d/%d stream(s)", len(stream_to_connector), len(stream_names))
 
-    # Fetch MktDataConnection for each unique DataConnectorId
+    # Fetch MktDataConnection for each unique DataConnectorId — in parallel to avoid
+    # O(n) sequential round-trips on orgs with many connectors.
     unique_ids = {cid for cid, _ in stream_to_connector.values()}
     connector_details: dict = {}
 
-    for connector_id in unique_ids:
+    def _fetch_one_connection(connector_id: str) -> Optional[dict]:
+        """Return parsed detail dict or None if the record should be skipped."""
         r = _http(
             "GET",
             f"{instance_url}/services/data/v{SF_API_VERSION}/tooling/sobjects/MktDataConnection/{connector_id}",
             headers=headers,
             verify=True,
             timeout=30,
-            allow_redirects=True,
         )
         if r.status_code == 404:
-            # Native same-org connectors (e.g. CRM) don't have a MktDataConnection record
             log.debug("  MktDataConnection %s not found (likely native connector) — skipping", connector_id)
-            continue
+            return None
         r.raise_for_status()
         try:
             data = r.json()
         except ValueError:
             log.warning("  MktDataConnection %s returned non-JSON — skipping", connector_id)
-            continue
+            return None
 
         metadata       = data.get("Metadata") or {}
         raw_params     = {
             p["paramName"]: p.get("value", "")
             for p in (metadata.get("parameters") or [])
-            if p.get("paramName")  # skip malformed entries missing the key name
+            if p.get("paramName")
         }
         connector_name = _sanitize_for_log(data.get("MasterLabel", ""))
         connector_type = _sanitize_for_log(metadata.get("connectorName") or "")
@@ -752,18 +799,15 @@ def fetch_connection_details(
             "connector_id":   connector_id,
             "connector_name": connector_name,
             "connector_type": connector_type,
-            "raw_params":     _redact_params(raw_params),  # never write credentials to disk
+            "raw_params":     _redact_params(raw_params),
         }
 
         if connector_type == _CONNECTOR_SNOWFLAKE:
             account_url_raw = raw_params.get("accountUrl", "")
             if account_url_raw:
-                # Validate with regex to reject subdomain-bypass attempts
-                # (e.g. host.snowflakecomputing.com.attacker.com.snowflakecomputing.com)
                 if _SNOWFLAKE_ACCT_URL_RE.match(account_url_raw):
                     _parsed_acct = urlparse(account_url_raw)
                     hostname = (_parsed_acct.hostname or "").lower()
-                    # Extra guard: hostname must contain snowflakecomputing.com exactly once
                     if hostname.count("snowflakecomputing.com") == 1:
                         account_url = _sanitize_for_log(account_url_raw)
                     else:
@@ -790,13 +834,23 @@ def fetch_connection_details(
                 detail["account_identifier"], detail["warehouse"],
             )
         else:
-            # Future connector types or external CRM orgs — expose raw_params for routing
             log.debug(
                 "  MktDataConnection %s (%s type=%s): %d params",
                 connector_id, connector_name, connector_type, len(raw_params),
             )
+        return detail
 
-        connector_details[connector_id] = detail
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {pool.submit(_fetch_one_connection, cid): cid for cid in unique_ids}
+        for future in concurrent.futures.as_completed(futures):
+            cid = futures[future]
+            try:
+                detail = future.result()
+            except Exception as exc:
+                log.warning("  MktDataConnection %s fetch failed: %s — skipping", cid, _sanitize_for_log(str(exc)))
+                detail = None
+            if detail is not None:
+                connector_details[cid] = detail
 
     for stream_name, (connector_id, _) in stream_to_connector.items():
         if connector_id in connector_details:
@@ -1066,8 +1120,8 @@ def resolve_edges(
             # Priority: crm_catalogs (multi-org map keyed by connector_id) → crm_idx (fallback).
             # Native same-org CRM streams have no MktDataConnection record, so connector_id
             # is absent from connection_details; they always fall back to crm_idx.
-            stream_name_crm  = _sanitize_for_log(stream.get("name", ""))
-            conn_info_crm    = _conn_details.get(stream_name_crm, {})
+            stream_name_crm  = _sanitize_for_log(stream.get("name", ""))  # logging only
+            conn_info_crm    = _conn_details.get(stream.get("name", ""), {})
             connector_id_crm = conn_info_crm.get("connector_id", "")
             # crm_catalogs keys are lowercased by _parse_warehouse_map; Salesforce IDs
             # are case-insensitive, so normalise before lookup.
@@ -1102,8 +1156,8 @@ def resolve_edges(
                 active_crm_uuid = crm_warehouse_uuid
             else:
                 log.warning(
-                    "  CRM stream found (DLO=%s) but no CRM warehouse is configured — skipping. "
-                    "Set MCD_CRM_WAREHOUSE_UUID or MCD_CRM_WAREHOUSE_MAP to enable CRM→DLO lineage.",
+                    "  CRM stream found (DLO=%s) but no CRM warehouse was found in MC — skipping. "
+                    "Ensure a Salesforce CRM connection exists in MC for this org.",
                     dlo_name,
                 )
                 _skip(stream, "crm_warehouse_uuid_not_configured", f"dlo_name={dlo_name}")
@@ -1143,8 +1197,8 @@ def resolve_edges(
         else:  # SNOWFLAKE
             # Route to the correct MC warehouse using the stream's Snowflake account identifier.
             # Priority: sf_catalogs (multi-warehouse map) → sf_idx (single-warehouse fallback).
-            stream_name  = _sanitize_for_log(stream.get("name", ""))
-            conn_info    = _conn_details.get(stream_name, {})
+            stream_name  = _sanitize_for_log(stream.get("name", ""))  # logging only
+            conn_info    = _conn_details.get(stream.get("name", ""), {})
             account_id   = conn_info.get("account_identifier", "")
             account_url  = conn_info.get("account_url", "")
 
@@ -1177,9 +1231,9 @@ def resolve_edges(
                     )
                 else:
                     log.warning(
-                        "  Snowflake stream found (DLO=%s, account=%s) but no warehouse is configured. "
-                        "Set MCD_SNOWFLAKE_WAREHOUSE_UUID or MCD_SNOWFLAKE_WAREHOUSE_MAP.",
-                        dlo_name, account_id or "unknown",
+                        "  Snowflake stream found (DLO=%s, account=%s) but no matching MC warehouse was found. "
+                        "Ensure a Snowflake connection exists in MC for account '%s'.",
+                        dlo_name, account_id or "unknown", account_id or "unknown",
                     )
                 _skip(stream, "snowflake_warehouse_not_configured",
                       f"dlo_name={dlo_name} account_identifier={account_id} account_url={account_url}")
@@ -1547,8 +1601,10 @@ class SalesforceService:
         )
 
     def authenticate(self) -> None:
-        self._token = get_sf_token(self.instance_url, self.client_id, self.client_secret)
-        self.client_secret = ""  # drop reference after use
+        try:
+            self._token = get_sf_token(self.instance_url, self.client_id, self.client_secret)
+        finally:
+            self.client_secret = ""  # drop reference regardless of success or failure
 
     @property
     def token(self) -> str:
@@ -1561,6 +1617,107 @@ class SalesforceService:
 
     def fetch_connection_details(self, streams: list) -> dict:
         return fetch_connection_details(self.instance_url, self.token, streams)
+
+    def invalidate_token(self) -> None:
+        self._token = ""
+
+
+def _discover_warehouse_uuids(
+    gql_key_id: str,
+    gql_key_secret: str,
+    sf_org_domain: str,
+) -> dict:
+    """
+    Queries MC getWarehouses and matches metadataConnection.identifiers to auto-discover:
+      - Data Cloud warehouse: SALESFORCE_DATA_CLOUD whose domain == SF_ORG_URL hostname
+      - CRM warehouse:        SALESFORCE_CRM whose domain == SF_ORG_URL hostname
+      - Snowflake warehouses: all SNOWFLAKE warehouses, keyed by account identifier (lowercase)
+
+    The domain match is exact (case-insensitive): MC stores the same hostname that
+    Salesforce reports in SF_ORG_URL, so there is no ambiguity or guessing.
+
+    Returns:
+      {"dc_uuid": str|None, "crm_uuid": str|None, "snowflake_map": {account_lower: uuid}}
+      dc_uuid / crm_uuid are None on failure OR when multiple matches are found (caller
+      should then require explicit env var override).
+    """
+    _EMPTY: dict = {"dc_uuid": None, "crm_uuid": None, "snowflake_map": {}}
+    query = """
+    query {
+      getWarehouses {
+        uuid connectionType
+        metadataConnection { identifiers }
+      }
+    }
+    """
+    try:
+        data = _gql(query, gql_key_id, gql_key_secret)
+        warehouses = (data or {}).get("getWarehouses") or []
+    except Exception as exc:
+        log.warning("  Warehouse auto-discovery failed (%s) — relying on env var overrides.", exc)
+        return _EMPTY
+
+    if len(warehouses) >= _MAX_WAREHOUSES_DISCOVERY:
+        log.error(
+            "  getWarehouses returned %d warehouse(s) — the result may be truncated. "
+            "Auto-discovery is unreliable for this account. Set MCD_DC_WAREHOUSE_UUID "
+            "(or MCD_RESOURCE_UUID), MCD_CRM_WAREHOUSE_UUID, and MCD_SNOWFLAKE_WAREHOUSE_MAP "
+            "as explicit overrides to bypass discovery.",
+            len(warehouses),
+        )
+
+    domain_lower = sf_org_domain.lower()
+    dc_matches: list = []
+    crm_matches: list = []
+    snowflake_map: dict = {}
+
+    for wh in warehouses:
+        ct   = wh.get("connectionType", "")
+        uuid = wh.get("uuid", "")
+        raw  = (wh.get("metadataConnection") or {}).get("identifiers") or "[]"
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except (ValueError, TypeError):
+                raw = []
+        idents = {
+            item["key"]: item.get("value", "")
+            for item in raw
+            if isinstance(item, dict) and "key" in item
+        }
+
+        if ct == "SALESFORCE_DATA_CLOUD":
+            if idents.get("domain", "").lower() == domain_lower:
+                dc_matches.append(uuid)
+        elif ct == "SALESFORCE_CRM":
+            if idents.get("domain", "").lower() == domain_lower:
+                crm_matches.append(uuid)
+        elif ct == "SNOWFLAKE":
+            acct = idents.get("account", "")
+            if acct:
+                snowflake_map[acct.lower()] = uuid
+
+    dc_uuid: Optional[str] = None
+    if len(dc_matches) > 1:
+        log.error(
+            "  Auto-discovery found %d Data Cloud warehouses for domain %r: %s. "
+            "Set MCD_DC_WAREHOUSE_UUID (or MCD_RESOURCE_UUID) to the correct UUID.",
+            len(dc_matches), sf_org_domain, ", ".join(dc_matches),
+        )
+    elif dc_matches:
+        dc_uuid = dc_matches[0]
+
+    crm_uuid: Optional[str] = None
+    if len(crm_matches) > 1:
+        log.error(
+            "  Auto-discovery found %d CRM warehouses for domain %r: %s. "
+            "Set MCD_CRM_WAREHOUSE_UUID to the correct UUID.",
+            len(crm_matches), sf_org_domain, ", ".join(crm_matches),
+        )
+    elif crm_matches:
+        crm_uuid = crm_matches[0]
+
+    return {"dc_uuid": dc_uuid, "crm_uuid": crm_uuid, "snowflake_map": snowflake_map}
 
 
 class MCLineageService:
@@ -1643,19 +1800,14 @@ def main() -> None:
         mcd_ingest_token = _require("MCD_INGEST_TOKEN")
         # Accept MCD_RESOURCE_UUID as an alias for MCD_DC_WAREHOUSE_UUID so that
         # users running both scripts from the same .env only need to set one variable.
+        # If neither is set, the UUID is auto-discovered from MC after SF auth.
         dc_warehouse_uuid = (
             os.environ.get("MCD_DC_WAREHOUSE_UUID")
             or os.environ.get("MCD_RESOURCE_UUID")
             or ""
         )
-        if not dc_warehouse_uuid:
-            log.error(
-                "Required environment variable 'MCD_DC_WAREHOUSE_UUID' is not set. "
-                "Also accepted as 'MCD_RESOURCE_UUID' (shared with push_lineage.py). "
-                "Find the UUID in Monte Carlo: Settings → Integrations → your Data Cloud connection."
-            )
-            sys.exit(1)
-        _validate_uuid("MCD_DC_WAREHOUSE_UUID", dc_warehouse_uuid)
+        if dc_warehouse_uuid:
+            _validate_uuid("MCD_DC_WAREHOUSE_UUID", dc_warehouse_uuid)
 
         crm_warehouse_uuid       = os.environ.get("MCD_CRM_WAREHOUSE_UUID")
         crm_warehouse_map_raw    = os.environ.get("MCD_CRM_WAREHOUSE_MAP", "")
@@ -1679,6 +1831,8 @@ def main() -> None:
             for acct_id, wh_uuid in sf_warehouse_map.items():
                 _validate_uuid(f"MCD_SNOWFLAKE_WAREHOUSE_MAP[{acct_id}]", wh_uuid)
             log.info("  Snowflake warehouse map: %d account(s) configured", len(sf_warehouse_map))
+
+        _batch_size = _parse_positive_int("INGEST_BATCH_SIZE", 500)
 
     # Salesforce creds — required for all modes including --discover
     sf_instance_url  = _require("SF_ORG_URL")
@@ -1750,7 +1904,47 @@ def main() -> None:
         need_crm = _CONNECTOR_SFDC in connector_types_present
         need_sf  = _CONNECTOR_SNOWFLAKE in connector_types_present
 
-        # Step 2b: Fetch connection details for all streams via MktDataConnection.
+        # Auto-discover MC warehouse UUIDs for any not provided via env vars.
+        # Matches by Salesforce org domain (CRM + Data Cloud) and Snowflake account ID.
+        _need_discovery = (
+            not dc_warehouse_uuid
+            or (need_crm and not crm_warehouse_uuid and not crm_warehouse_map)
+            or (need_sf and not sf_warehouse_map)
+        )
+        if _need_discovery:
+            sf_org_domain = _parsed_url.hostname or ""
+            log.info(
+                "Step 2b (discovery): Auto-discovering MC warehouse UUIDs for org: %s",
+                sf_org_domain,
+            )
+            _disc = _discover_warehouse_uuids(mcd_id, mcd_token, sf_org_domain)
+            if not dc_warehouse_uuid and _disc["dc_uuid"]:
+                dc_warehouse_uuid = _disc["dc_uuid"]
+                _validate_uuid("MCD_DC_WAREHOUSE_UUID", dc_warehouse_uuid)
+                log.info("  Discovered Data Cloud warehouse: %s", dc_warehouse_uuid)
+            if need_crm and not crm_warehouse_uuid and not crm_warehouse_map and _disc["crm_uuid"]:
+                crm_warehouse_uuid = _disc["crm_uuid"]
+                _validate_uuid("discovered CRM warehouse", crm_warehouse_uuid)
+                log.info("  Discovered CRM warehouse: %s", crm_warehouse_uuid)
+            if need_sf and not sf_warehouse_map and _disc["snowflake_map"]:
+                for _acct, _wh_uuid in _disc["snowflake_map"].items():
+                    _validate_uuid(f"discovered Snowflake warehouse for {_acct}", _wh_uuid)
+                sf_warehouse_map = _disc["snowflake_map"]
+                log.info(
+                    "  Discovered %d Snowflake warehouse(s): %s",
+                    len(sf_warehouse_map), ", ".join(sf_warehouse_map),
+                )
+
+        if not dc_warehouse_uuid:
+            log.error(
+                "Could not determine the Data Cloud warehouse UUID. "
+                "Set MCD_RESOURCE_UUID in your .env, or ensure your MC account has a "
+                "Salesforce Data Cloud connection for this org (%s).",
+                _parsed_url.hostname or sf_instance_url,
+            )
+            sys.exit(1)
+
+        # Step 2d: Fetch connection details for all streams via MktDataConnection.
         # Covers Snowflake (account routing) and any future connector types.
         # Native same-org CRM connections will not have a MktDataConnection record
         # and are silently omitted.
@@ -1774,6 +1968,29 @@ def main() -> None:
                     exc,
                 )
 
+        # SF API calls are done — drop the token from memory
+        sf_svc.invalidate_token()
+
+        # Eager catalog filter: trim sf_warehouse_map to only accounts actually referenced by
+        # streams. Auto-discovery may return every Snowflake warehouse connected to MC; without
+        # this filter we'd fetch a catalog for each one even if only one account is in use.
+        if need_sf and sf_warehouse_map and connection_details:
+            referenced_accounts = {
+                info.get("account_identifier", "").lower()
+                for info in connection_details.values()
+                if info.get("account_identifier")
+            }
+            if referenced_accounts:
+                pruned = {k: v for k, v in sf_warehouse_map.items() if k in referenced_accounts}
+                dropped = set(sf_warehouse_map) - set(pruned)
+                if dropped:
+                    log.info(
+                        "  Snowflake warehouse map pruned to %d account(s) referenced by streams "
+                        "(dropped unreferenced: %s)",
+                        len(pruned), ", ".join(sorted(dropped)),
+                    )
+                sf_warehouse_map = pruned
+
         # Step 3: Fetch catalogs for the warehouses we need
         t3 = time.monotonic()
         log.info("Step 3: Fetching MC catalog(s)")
@@ -1791,8 +2008,9 @@ def main() -> None:
                 crm_idx = mc_svc.fetch_catalog(crm_warehouse_uuid, "Salesforce CRM")
             elif not crm_warehouse_map:
                 log.warning(
-                    "  CRM streams detected but neither MCD_CRM_WAREHOUSE_UUID nor "
-                    "MCD_CRM_WAREHOUSE_MAP is set. CRM→DLO edges will be skipped."
+                    "  CRM streams detected but no CRM warehouse was found in MC for this org. "
+                    "CRM→DLO edges will be skipped. Ensure a Salesforce CRM connection exists in MC "
+                    "for this org, or set MCD_CRM_WAREHOUSE_UUID as an override."
                 )
 
         # Build sf_catalogs: {account_identifier → (_CatalogIndex, warehouse_uuid)}
@@ -1813,8 +2031,9 @@ def main() -> None:
                 sf_idx = mc_svc.fetch_catalog(snowflake_warehouse_uuid, "Snowflake (fallback)")
             elif not sf_warehouse_map:
                 log.warning(
-                    "  Snowflake streams detected but neither MCD_SNOWFLAKE_WAREHOUSE_UUID "
-                    "nor MCD_SNOWFLAKE_WAREHOUSE_MAP is set. Snowflake→DLO edges will be skipped."
+                    "  Snowflake streams detected but no Snowflake warehouse was found in MC. "
+                    "Snowflake→DLO edges will be skipped. Ensure a Snowflake connection exists in MC, "
+                    "or set MCD_SNOWFLAKE_WAREHOUSE_UUID as an override."
                 )
 
         log.info("  Step 3 complete (%.1fs)", time.monotonic() - t3)
@@ -1893,7 +2112,6 @@ def main() -> None:
         )
         sys.exit(0)
 
-    _batch_size = int(os.environ.get("INGEST_BATCH_SIZE", "500"))
     try:
         pushed_count = mc_svc.push_edges(edges, run_id, _batch_size, _shutdown_requested)
     except KeyboardInterrupt:

--- a/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
@@ -1803,13 +1803,13 @@ def main() -> None:
         # Accept MCD_RESOURCE_UUID as an alias for MCD_DC_WAREHOUSE_UUID so that
         # users running both scripts from the same .env only need to set one variable.
         # If neither is set, the UUID is auto-discovered from MC after SF auth.
-        dc_warehouse_uuid = (
-            os.environ.get("MCD_DC_WAREHOUSE_UUID")
-            or os.environ.get("MCD_RESOURCE_UUID")
-            or ""
+        _dc_uuid_var = (
+            "MCD_DC_WAREHOUSE_UUID" if os.environ.get("MCD_DC_WAREHOUSE_UUID")
+            else "MCD_RESOURCE_UUID"
         )
+        dc_warehouse_uuid = os.environ.get("MCD_DC_WAREHOUSE_UUID") or os.environ.get("MCD_RESOURCE_UUID") or ""
         if dc_warehouse_uuid:
-            _validate_uuid("MCD_DC_WAREHOUSE_UUID", dc_warehouse_uuid)
+            _validate_uuid(_dc_uuid_var, dc_warehouse_uuid)
 
         crm_warehouse_uuid       = os.environ.get("MCD_CRM_WAREHOUSE_UUID")
         crm_warehouse_map_raw    = os.environ.get("MCD_CRM_WAREHOUSE_MAP", "")

--- a/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
@@ -84,6 +84,7 @@ load_dotenv(dotenv_path=Path(__file__).parent / ".env")
 # ── Constants ─────────────────────────────────────────────────────────────────
 SF_API_VERSION = "62.0"
 MC_GRAPHQL_URL = "https://api.getmontecarlo.com/graphql"
+MC_INGEST_URL  = "https://integrations.getmontecarlo.com"
 
 _CONNECTOR_SFDC = "SalesforceDotCom"
 _CONNECTOR_SNOWFLAKE = "SNOWFLAKE"
@@ -1497,6 +1498,7 @@ def push_edges(
         mcd_id=ingest_key_id,
         mcd_token=ingest_key_secret,
         scope="Ingestion",
+        endpoint=MC_INGEST_URL,
     )))
 
     _resource_type_map = {
@@ -1778,7 +1780,7 @@ def main() -> None:
     def _handle_sigterm(signum, frame):  # noqa: ANN001
         log.warning(
             "Received SIGTERM — stop requested. "
-            "Push will halt cleanly after the current edge. Re-run is safe (idempotent)."
+            "Push will halt cleanly after the current batch. Re-run is safe (idempotent)."
         )
         _shutdown_requested.set()
     signal.signal(signal.SIGTERM, _handle_sigterm)

--- a/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
@@ -1,0 +1,1880 @@
+#!/usr/bin/env python3
+"""
+Data 360 External Source → DLO Lineage Push
+
+Pushes CRM→DLO and Snowflake→DLO lineage edges into Monte Carlo using the
+createOrUpdateLineageEdge GraphQL mutation so that external source tables
+appear as trusted lineage upstream of Data 360 Data Lake Objects.
+
+Only sources that already exist as first-class objects in a Monte Carlo
+warehouse catalog (CRM tables, Snowflake tables) are linked. Sources that
+require custom node creation (e.g. S3 files) are out of scope.
+
+Pipeline:
+  1. Authenticate with Salesforce (platform OAuth — org-wide, same token for all data spaces)
+  2. Fetch all Data Streams from the Salesforce Connect REST API
+  3. Fetch MC catalog tables for Data Cloud, CRM, and/or Snowflake warehouses
+  4. Match each stream's source table and DLO to MC catalog entries
+  5. Push lineage edges via createOrUpdateLineageEdge GraphQL mutation
+
+Usage:
+  python3 push_external_lineage.py --dry-run
+  python3 push_external_lineage.py
+  python3 push_external_lineage.py --discover   # scan DSO connector types, no MC push
+
+Required env vars (see .env.example):
+  SF_ORG_URL, SF_CLIENT_ID, SF_CLIENT_SECRET
+  MCD_ID, MCD_TOKEN              — Personal API key (catalog lookup + lineage push)
+                                   Note: this integration uses a single Personal API key for
+                                   both catalog lookups (getTables) and lineage push
+                                   (createOrUpdateLineageEdge). No separate Ingestion key is
+                                   needed; invocation_ids are a Pandora Ingestion-API concept
+                                   and do not apply to the GraphQL mutation path used here.
+  MCD_DC_WAREHOUSE_UUID          — Monte Carlo Data Cloud warehouse UUID
+
+Optional env vars:
+  MCD_CRM_WAREHOUSE_UUID         — MC CRM warehouse UUID (single-org fallback)
+  MCD_CRM_WAREHOUSE_MAP          — Multi-org CRM map: "connector_id1=uuid1,connector_id2=uuid2"
+                                   connector_id is the DataConnectorId from DataStreamDefinition.
+                                   Used for linked/external CRM org streams; native same-org
+                                   streams fall back to MCD_CRM_WAREHOUSE_UUID.
+                                   Takes precedence over MCD_CRM_WAREHOUSE_UUID when set.
+  MCD_SNOWFLAKE_WAREHOUSE_UUID   — MC Snowflake warehouse UUID (single-warehouse fallback)
+  MCD_SNOWFLAKE_WAREHOUSE_MAP    — Multi-warehouse map: "account_id=uuid,account_id2=uuid2"
+                                   account_id is the Snowflake account identifier extracted from
+                                   the accountUrl in MktDataConnection (e.g. "hdb68299.us-west-2")
+                                   Takes precedence over MCD_SNOWFLAKE_WAREHOUSE_UUID when set.
+  LOG_LEVEL                      — DEBUG/INFO/WARNING/ERROR (default: INFO)
+  LOG_FORMAT                     — json for structured output (default: plain)
+"""
+import argparse
+import ipaddress
+import json
+import logging
+import os
+import re
+import signal
+import sys
+import threading
+import time
+import uuid as uuid_module
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NamedTuple, Optional
+from urllib.parse import urlparse
+
+import requests
+from dotenv import load_dotenv
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+SF_API_VERSION = "62.0"
+MC_GRAPHQL_URL = "https://api.getmontecarlo.com/graphql"
+
+_CONNECTOR_SFDC = "SalesforceDotCom"
+_CONNECTOR_SNOWFLAKE = "SNOWFLAKE"
+_SUPPORTED_CONNECTORS = {_CONNECTOR_SFDC, _CONNECTOR_SNOWFLAKE}
+
+# Safety ceiling for pagination loops — prevents runaway fetches from a buggy/malicious API
+_MAX_PAGES = 500
+
+# Maximum response body size allowed before JSON parsing — guards against memory exhaustion
+# from a malicious or misconfigured server sending a very large response body.
+_MAX_RESPONSE_BYTES = 50 * 1024 * 1024  # 50 MB
+
+# Batch size for SOQL IN clauses — keeps each query well under URL and record-count limits.
+# Salesforce Tooling API returns at most 2000 records per response; batching at 200 keeps
+# each batch comfortably under that limit and avoids URL length errors at scale.
+_TOOLING_SOQL_BATCH_SIZE = 200
+
+# Maximum per-retry sleep for 429 rate-limit responses
+_RETRY_AFTER_MAX = 30.0
+
+# Salesforce DeveloperName / API Name: alphanumeric + underscore, 1-255 chars.
+# Used to validate names before embedding in SOQL IN clauses.
+_SF_DEVELOPER_NAME_RE = re.compile(r"^[A-Za-z0-9_]{1,255}$")
+
+# Salesforce record ID: 15 or 18 alphanumeric characters.
+# Validated before embedding in Tooling API URL paths.
+_SF_ID_RE = re.compile(r"^[A-Za-z0-9]{15,18}$")
+
+# Snowflake account URL: must be exactly https://<account>.snowflakecomputing.com.
+# Rejects subdomain-bypass attempts (e.g. foo.snowflakecomputing.com.evil.snowflakecomputing.com).
+_SNOWFLAKE_ACCT_URL_RE = re.compile(
+    r"^https://[a-z0-9][a-z0-9\-\.]*\.snowflakecomputing\.com(?::\d+)?/?$",
+    re.IGNORECASE,
+)
+
+# Log-injection hardening: BIDI override characters and ANSI escape sequences.
+_BIDI_OVERRIDES = frozenset([
+    "\u202a", "\u202b", "\u202c", "\u202d", "\u202e",
+    "\u200e", "\u200f", "\u2066", "\u2067", "\u2068", "\u2069",
+])
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+# Param names that may contain credentials — redacted before writing to disk.
+_SENSITIVE_PARAM_NAMES = frozenset({
+    "password", "secret", "token", "key", "apikey", "api_key",
+    "clientsecret", "client_secret", "accesskey", "access_key",
+    "secretaccesskey", "secret_access_key", "privatekey", "private_key",
+    "sessiontoken", "session_token",
+    "passphrase",
+    "pkcs8privatekey", "pkcs8_private_key",
+    "sshprivatekey", "ssh_private_key",
+    "bearertoken", "bearer_token",
+    "oauthtoken", "oauth_token",
+})
+
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        data: dict = {
+            "ts":     datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level":  record.levelname,
+            "run_id": getattr(record, "run_id", ""),
+            "msg":    record.getMessage(),
+        }
+        if record.exc_info:
+            data["exc"] = self.formatException(record.exc_info)
+        return json.dumps(data)
+
+
+class _RunIdFilter(logging.Filter):
+    def __init__(self, run_id: str) -> None:
+        super().__init__()
+        self.run_id = run_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.run_id = self.run_id  # type: ignore[attr-defined]
+        return True
+
+
+def _setup_logging(run_id: str) -> logging.Logger:
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    _valid_levels = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+    if level_name not in _valid_levels:
+        print(
+            f"WARNING: Unknown LOG_LEVEL={level_name!r}, using INFO. "
+            f"Valid values: {', '.join(_valid_levels)}",
+            file=sys.stderr,
+        )
+        level_name = "INFO"
+    level = getattr(logging, level_name, logging.INFO)
+
+    use_json = os.environ.get("LOG_FORMAT", "").lower() == "json"
+    plain_fmt = logging.Formatter(
+        "[%(asctime)s] [%(levelname)-7s] [run=%(run_id)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    json_fmt = _JsonFormatter()
+
+    # stderr handler
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.addFilter(_RunIdFilter(run_id))
+    stderr_handler.setFormatter(json_fmt if use_json else plain_fmt)
+
+    # file handler — always plain text regardless of LOG_FORMAT so it's human-readable
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    log_path = Path(__file__).parent / f"run_{run_id}_{ts}.log"
+    # Create the log file with 0o600 permissions (owner read/write only).
+    # os.umask(0o177) masks off group/other bits so FileHandler creates it at 0o600.
+    _old_umask = os.umask(0o177)
+    try:
+        file_handler = logging.FileHandler(str(log_path), encoding="utf-8")
+    finally:
+        os.umask(_old_umask)
+    file_handler.addFilter(_RunIdFilter(run_id))
+    file_handler.setFormatter(plain_fmt)
+
+    logger = logging.getLogger("push_external_lineage")
+    logger.setLevel(level)
+    logger.handlers = [stderr_handler, file_handler]
+    logger.propagate = False
+
+    # Announce the log file path on stderr before any other output
+    print(f"[run={run_id}] Log file: {log_path.resolve()}", file=sys.stderr)
+    return logger
+
+
+log: logging.Logger = logging.getLogger("push_external_lineage")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+def _require(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        log.error(
+            "Required environment variable '%s' is not set. "
+            "Set it in your .env file (see .env.example for the expected format).",
+            name,
+        )
+        sys.exit(1)
+    return val
+
+
+def _sanitize_for_log(value: str, max_len: int = 300) -> str:
+    """Strip control/injection characters from API strings before embedding in logs."""
+    out = value.replace("\n", " ").replace("\r", " ").replace("\t", " ").replace("\x00", "")
+    out = out.replace("\u2028", " ").replace("\u2029", " ")  # Unicode line/paragraph separators
+    out = _ANSI_ESCAPE_RE.sub("", out)
+    out = "".join(" " if c in _BIDI_OVERRIDES else c for c in out)
+    return out[:max_len]
+
+
+def _url_for_log(url: str) -> str:
+    """Strip query string from a URL before logging — keeps SOQL queries and cursors out of logs."""
+    return urlparse(url)._replace(query="").geturl()
+
+
+class MCGraphQLError(RuntimeError):
+    """Raised for application-level GraphQL errors (error array in response body).
+
+    These are permanent failures that must NOT be retried — the server understood the
+    request and rejected it. Transport errors (network, 5xx) use RuntimeError/RequestException.
+    """
+
+
+def _redact_params(params: dict) -> dict:
+    """Return a copy of params with sensitive values replaced by '<redacted>'."""
+    redacted: dict = {}
+    for k, v in params.items():
+        redacted[k] = "<redacted>" if k.lower().replace("-", "_") in _SENSITIVE_PARAM_NAMES else v
+    return redacted
+
+
+def _sanitize_stream_for_disk(stream: dict) -> dict:
+    """Return a stream dict with credential-bearing nested dicts redacted.
+
+    Covers connectorInfo.connectorDetails (nested and top-level) and advancedAttributes,
+    which may contain Snowflake passwords, S3 keys, or other secrets embedded in the
+    Salesforce API response. Non-dict values are replaced with {} rather than crashing.
+    """
+    result = dict(stream)
+    connector_info = dict(result.get("connectorInfo") or {})
+    if "connectorDetails" in connector_info:
+        cd = connector_info.get("connectorDetails")
+        connector_info["connectorDetails"] = _redact_params(cd if isinstance(cd, dict) else {})
+    result["connectorInfo"] = connector_info
+    if "connectorDetails" in result:
+        cd = result.get("connectorDetails")
+        result["connectorDetails"] = _redact_params(cd if isinstance(cd, dict) else {})
+    if "advancedAttributes" in result:
+        aa = result.get("advancedAttributes")
+        result["advancedAttributes"] = _redact_params(aa if isinstance(aa, dict) else {})
+    return result
+
+
+def _validate_uuid(name: str, value: str) -> None:
+    """Validate that value is a well-formed UUID; exit with a clear error if not."""
+    try:
+        uuid_module.UUID(value)
+    except ValueError:
+        log.error(
+            "Environment variable '%s' is not a valid UUID (got: %r). "
+            "Find the correct UUID in Monte Carlo: Settings → Integrations → your connection.",
+            name, value,
+        )
+        sys.exit(1)
+
+
+def _extract_sf_account_identifier(account_url: str) -> str:
+    """Extract lowercased account identifier from a Snowflake accountUrl.
+
+    'https://HDB68299.us-west-2.snowflakecomputing.com' → 'hdb68299.us-west-2'
+    'https://xy12345.snowflakecomputing.com'            → 'xy12345'
+    """
+    parsed = urlparse(account_url)
+    hostname = (parsed.hostname or "").lower()
+    suffix = ".snowflakecomputing.com"
+    if hostname.endswith(suffix):
+        return hostname[: -len(suffix)]
+    return hostname
+
+
+def _parse_warehouse_map(raw: str) -> dict:
+    """Parse a warehouse map env var into {key.lower(): uuid}.
+
+    Format: 'key1=uuid1,key2=uuid2'
+    Logs a warning for any entry that cannot be parsed (missing '=', empty key, or empty uuid).
+    """
+    if len(raw) > 8192:
+        # Truncate at the last complete comma boundary to avoid a split key=uuid entry
+        raw = raw[:8192]
+        last_comma = raw.rfind(",")
+        if last_comma != -1:
+            raw = raw[:last_comma]
+        log.warning(
+            "Warehouse map env var is unexpectedly long — truncated to last complete entry"
+        )
+    result: dict = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            log.warning("Warehouse map entry %r is malformed (expected key=uuid) — skipped", pair)
+            continue
+        key, uuid_val = pair.split("=", 1)
+        key = key.strip().lower()
+        uuid_val = uuid_val.strip()
+        if not key or not uuid_val:
+            log.warning(
+                "Warehouse map entry %r has empty key or UUID after parsing — skipped", pair
+            )
+            continue
+        result[key] = uuid_val
+    return result
+
+
+def _http(
+    method: str,
+    url: str,
+    *,
+    max_retries: int = 3,
+    backoff_base: float = 1.0,
+    **kwargs,
+) -> requests.Response:
+    """HTTP with exponential backoff, 429 rate-limit handling, and 5xx retry.
+
+    Defaults allow_redirects=False to prevent redirect-based SSRF — callers that need
+    redirects must explicitly pass allow_redirects=True.
+    """
+    kwargs.setdefault("allow_redirects", False)
+    kwargs.setdefault("timeout", 30)  # safety net — all callers should set explicitly
+    _log_url = _url_for_log(url)  # strip query string before any log calls
+
+    for attempt in range(max_retries + 1):
+        try:
+            resp = requests.request(method, url, **kwargs)
+        except requests.exceptions.RequestException as exc:
+            if attempt >= max_retries:
+                raise
+            wait = backoff_base * (2 ** attempt)
+            log.warning(
+                "HTTP %s %s failed (attempt %d/%d): %s — retrying in %.1fs",
+                method, _log_url, attempt + 1, max_retries + 1, exc, wait,
+            )
+            time.sleep(wait)
+            continue
+
+        if resp.status_code == 429:
+            if attempt >= max_retries:
+                resp.raise_for_status()
+            try:
+                retry_after = float(resp.headers.get("Retry-After", 0))
+                wait = min(retry_after, _RETRY_AFTER_MAX) if retry_after > 0 else backoff_base * (2 ** attempt)
+            except (ValueError, TypeError):
+                wait = backoff_base * (2 ** attempt)
+            log.warning(
+                "Rate limited (429) on %s — waiting %.1fs (retry %d/%d)",
+                _log_url, wait, attempt + 1, max_retries,
+            )
+            time.sleep(wait)
+            continue
+
+        if resp.status_code >= 500 and attempt < max_retries:
+            wait = backoff_base * (2 ** attempt)
+            log.warning(
+                "Server error %d on %s (attempt %d/%d) — retrying in %.1fs",
+                resp.status_code, _log_url, attempt + 1, max_retries + 1, wait,
+            )
+            time.sleep(wait)
+            continue
+
+        # Raise explicitly on unexpected redirects — prevents silent 3xx pass-through
+        # when allow_redirects=False is in effect.
+        if 300 <= resp.status_code < 400:
+            location = _sanitize_for_log(resp.headers.get("Location", "?"))
+            raise requests.exceptions.TooManyRedirects(
+                f"Redirect ({resp.status_code}) blocked on {_log_url} — "
+                f"allow_redirects is False. Location: {location!r}"
+            )
+
+        return resp
+
+    raise RuntimeError("_http retry loop exhausted unexpectedly")
+
+
+# ── GraphQL helper ────────────────────────────────────────────────────────────
+def _gql(query: str, key_id: str, key_secret: str, variables: Optional[dict] = None) -> dict:
+    payload: dict = {"query": query}
+    if variables is not None:
+        payload["variables"] = variables
+    resp = _http(
+        "POST",
+        MC_GRAPHQL_URL,
+        json=payload,
+        headers={
+            "x-mcd-id":     key_id,
+            "x-mcd-token":  key_secret,
+            "Content-Type": "application/json",
+        },
+        timeout=30,
+        verify=True,
+        max_retries=0,  # retry responsibility delegated to tenacity at the push layer
+    )
+    resp.raise_for_status()
+    if len(resp.content) > _MAX_RESPONSE_BYTES:
+        raise RuntimeError(
+            f"MC GraphQL response body is too large ({len(resp.content):,} bytes > "
+            f"{_MAX_RESPONSE_BYTES:,} byte limit). Refusing to parse."
+        )
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        log.debug("MC GraphQL non-JSON response body: %s", _sanitize_for_log(resp.text, max_len=500))
+        raise RuntimeError(
+            f"MC GraphQL returned non-JSON response (status={resp.status_code}). "
+            "Enable DEBUG logging for the response body."
+        ) from exc
+    if "errors" in body:
+        msgs = [_sanitize_for_log(e.get("message", str(e))) for e in body["errors"]]
+        hint = (
+            " (source node does not exist in MC catalog — "
+            "register it via Push Ingest API before linking)"
+            if any("not found" in m.lower() for m in msgs)
+            else " (verify MCD_ID/MCD_TOKEN are a Personal API key, not an Ingestion key)"
+        )
+        raise MCGraphQLError(f"MC GraphQL error: {'; '.join(msgs)}.{hint}")
+    data = body.get("data")
+    if data is None:
+        raise MCGraphQLError(
+            f"MC GraphQL returned null/missing 'data' field (status={resp.status_code}). "
+            "This may indicate a gateway-level error."
+        )
+    return data
+
+
+# ── Step 1: Salesforce OAuth ──────────────────────────────────────────────────
+def get_sf_token(instance_url: str, client_id: str, client_secret: str) -> str:
+    t0 = time.monotonic()
+    log.info("Step 1: Authenticating with Salesforce (%s)", instance_url)
+    resp = _http(
+        "POST",
+        f"{instance_url}/services/oauth2/token",
+        data={
+            "grant_type":    "client_credentials",
+            "client_id":     client_id,
+            "client_secret": client_secret,
+        },
+        verify=True,
+        timeout=30,
+        allow_redirects=True,  # Salesforce may 302 on org migrations / MyDomain moves
+    )
+    try:
+        data = resp.json()
+    except ValueError:
+        resp.raise_for_status()
+        raise RuntimeError(
+            f"Salesforce auth returned non-JSON response (status={resp.status_code})"
+        )
+    if "error" in data:
+        raise RuntimeError(
+            f"Salesforce auth failed: {_sanitize_for_log(str(data.get('error')))} — "
+            f"{_sanitize_for_log(str(data.get('error_description', '')))}"
+        )
+    resp.raise_for_status()
+    token = data.get("access_token")
+    if not token:
+        log.debug("Salesforce auth response keys: %s", list(data.keys()))
+        raise RuntimeError(
+            f"Salesforce auth response missing access_token (status={resp.status_code}). "
+            "Enable DEBUG logging to inspect the response body."
+        )
+    log.info("  Authenticated (%.1fs)", time.monotonic() - t0)
+    return token
+
+
+# ── Step 2: Fetch Data Streams ────────────────────────────────────────────────
+def fetch_data_streams(instance_url: str, access_token: str) -> list:
+    """
+    Fetch all Data Streams from the Salesforce Connect REST API.
+    Paginates via nextPageUrl; enforces same-origin validation on each page URL
+    to prevent SSRF via a malicious API response.
+    """
+    t0 = time.monotonic()
+    log.info("Step 2: Fetching Data Streams from Salesforce")
+    streams: list = []
+    url: Optional[str] = f"{instance_url}/services/data/v{SF_API_VERSION}/ssot/data-streams"
+    headers = {"Authorization": f"Bearer {access_token}"}
+    page = 0
+    instance_parsed = urlparse(instance_url)
+
+    while url:
+        page += 1
+        if page > _MAX_PAGES:
+            raise RuntimeError(
+                f"Data Streams pagination safety limit ({_MAX_PAGES} pages) exceeded. "
+                "This likely indicates a Salesforce API bug or a runaway response."
+            )
+
+        resp = _http("GET", url, headers=headers, verify=True, timeout=30, allow_redirects=True)
+        resp.raise_for_status()
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            log.debug("Data Streams API non-JSON response: %s", _sanitize_for_log(resp.text, max_len=500))
+            raise RuntimeError(
+                f"Data Streams API returned non-JSON response (status={resp.status_code}). "
+                "Enable DEBUG logging for the response body."
+            ) from exc
+
+        page_streams = body.get("dataStreams") or []
+        streams.extend(page_streams)
+        log.info("  Page %d: %d stream(s) fetched (%d total)", page, len(page_streams), len(streams))
+
+        next_path = body.get("nextPageUrl")
+        if not next_path:
+            break
+
+        # Construct and validate the next page URL before following it (SSRF guard)
+        next_url = next_path if next_path.startswith("https://") else f"{instance_url}{next_path}"
+        next_parsed = urlparse(next_url)
+        if next_parsed.scheme != "https" or next_parsed.netloc != instance_parsed.netloc:
+            raise RuntimeError(
+                f"Salesforce nextPageUrl has unexpected origin (got: {next_url!r}, "
+                f"expected scheme=https host={instance_parsed.netloc}). Aborting to prevent SSRF."
+            )
+        url = next_url
+
+    log.info("  %d total data stream(s) (%.1fs)", len(streams), time.monotonic() - t0)
+    return streams
+
+
+# ── Step 2b: Fetch connection details (all connector types) ───────────────────
+def fetch_connection_details(
+    instance_url: str,
+    access_token: str,
+    streams: list,
+) -> dict:
+    """
+    For every data stream, attempt to look up its MktDataConnection via the
+    Tooling API to retrieve source connection parameters.
+
+    Lookup path:
+      DataStreamDefinition (Tooling API) → DataConnectorId
+      → MktDataConnection → Metadata.parameters.*
+
+    Returns dict mapping stream_name → connection detail dict. All entries
+    include at minimum:
+        "connector_id":   str,   DataConnectorId (routing key for warehouse maps)
+        "connector_name": str,   MktDataConnection MasterLabel
+        "connector_type": str,   e.g. "SNOWFLAKE", "AwsS3", "SalesforceDotCom"
+        "raw_params":     dict,  all Metadata.parameters as {name: value}
+
+    Additional type-specific fields:
+
+    SNOWFLAKE:
+        "account_url":        str,   "https://HDB68299.us-west-2.snowflakecomputing.com"
+        "account_identifier": str,   "hdb68299.us-west-2" (lowercased, routing key)
+        "warehouse":          str,   Snowflake virtual warehouse name
+        "region":             str,   Snowflake region
+
+    AwsS3:
+        "bucket_name":        str,   e.g. "my-data-bucket"
+        "parent_directory":   str,   e.g. "/" or "data/feeds"
+
+    SalesforceDotCom (native same-org connections):
+        MktDataConnection may not exist — entry omitted for those streams.
+        External linked-org CRM connections will resolve and expose whatever
+        parameters Salesforce stores (typically instanceUrl or orgId).
+
+    Streams for which no MktDataConnection exists (e.g. native CRM connections)
+    are omitted from the result — callers should fall back to their single
+    warehouse UUID env var for those streams.
+    """
+    t0 = time.monotonic()
+    log.info("Step 2b: Fetching connection details for all streams via Tooling API")
+
+    # Validate stream names before embedding in SOQL IN clauses.
+    raw_names = [s.get("name", "") for s in streams if s.get("name")]
+    stream_names = []
+    for n in raw_names:
+        if _SF_DEVELOPER_NAME_RE.fullmatch(n):
+            stream_names.append(n)
+        else:
+            log.warning(
+                "  Stream name %r failed DeveloperName validation — "
+                "excluding from SOQL query (unexpected characters)",
+                _sanitize_for_log(n),
+            )
+    if not stream_names:
+        return {}
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    result: dict = {}
+
+    # Query DataStreamDefinition for all stream names → DataConnectorId.
+    # Batched (_TOOLING_SOQL_BATCH_SIZE per query) to avoid URL length limits at scale.
+    # Each batch paginates via nextRecordsUrl to handle responses truncated at 2000 records.
+    stream_to_connector: dict = {}
+    instance_parsed_tooling = urlparse(instance_url)
+
+    for batch_start in range(0, len(stream_names), _TOOLING_SOQL_BATCH_SIZE):
+        batch = stream_names[batch_start : batch_start + _TOOLING_SOQL_BATCH_SIZE]
+        names_in = ", ".join(f"'{n}'" for n in batch)
+        soql_query = (
+            "SELECT DeveloperName, DataConnectorId, DataConnectorType "
+            f"FROM DataStreamDefinition WHERE DeveloperName IN ({names_in})"
+        )
+        tooling_url: Optional[str] = (
+            f"{instance_url}/services/data/v{SF_API_VERSION}/tooling/query/"
+        )
+        tooling_params: Optional[dict] = {"q": soql_query}
+        soql_page = 0
+
+        while tooling_url:
+            soql_page += 1
+            if soql_page > _MAX_PAGES:
+                raise RuntimeError(
+                    f"DataStreamDefinition SOQL pagination safety limit "
+                    f"({_MAX_PAGES} pages) exceeded."
+                )
+            resp = _http(
+                "GET",
+                tooling_url,
+                params=tooling_params,
+                headers=headers,
+                verify=True,
+                timeout=30,
+                allow_redirects=True,
+            )
+            resp.raise_for_status()
+            try:
+                body = resp.json()
+            except ValueError as exc:
+                raise RuntimeError(
+                    "DataStreamDefinition tooling query returned non-JSON response"
+                ) from exc
+
+            for rec in (body.get("records") or []):
+                name         = rec.get("DeveloperName") or ""
+                connector_id = rec.get("DataConnectorId") or ""
+                conn_type    = rec.get("DataConnectorType") or ""
+                if not (name and connector_id):
+                    continue
+                if not _SF_ID_RE.fullmatch(connector_id):
+                    log.warning(
+                        "  DataConnectorId %r for stream %r failed ID validation — skipping",
+                        _sanitize_for_log(connector_id), _sanitize_for_log(name),
+                    )
+                    continue
+                stream_to_connector[name] = (connector_id, conn_type)
+
+            next_path = body.get("nextRecordsUrl")
+            if body.get("done", True) or not next_path:
+                break
+            # Validate same-origin before following nextRecordsUrl (SSRF guard)
+            next_url = (
+                next_path if next_path.startswith("https://")
+                else f"{instance_url}{next_path}"
+            )
+            next_parsed_t = urlparse(next_url)
+            if (next_parsed_t.scheme != "https"
+                    or next_parsed_t.netloc != instance_parsed_tooling.netloc):
+                raise RuntimeError(
+                    f"DataStreamDefinition nextRecordsUrl has unexpected origin "
+                    f"(got: {next_url!r}, expected host={instance_parsed_tooling.netloc}). "
+                    "Aborting to prevent SSRF."
+                )
+            tooling_url = next_url
+            tooling_params = None  # nextRecordsUrl already encodes query params
+
+    if not stream_to_connector:
+        log.info("  No DataConnectorId found for any streams — connection details unavailable")
+        return {}
+
+    log.info("  Found DataConnectorId for %d/%d stream(s)", len(stream_to_connector), len(stream_names))
+
+    # Fetch MktDataConnection for each unique DataConnectorId
+    unique_ids = {cid for cid, _ in stream_to_connector.values()}
+    connector_details: dict = {}
+
+    for connector_id in unique_ids:
+        r = _http(
+            "GET",
+            f"{instance_url}/services/data/v{SF_API_VERSION}/tooling/sobjects/MktDataConnection/{connector_id}",
+            headers=headers,
+            verify=True,
+            timeout=30,
+            allow_redirects=True,
+        )
+        if r.status_code == 404:
+            # Native same-org connectors (e.g. CRM) don't have a MktDataConnection record
+            log.debug("  MktDataConnection %s not found (likely native connector) — skipping", connector_id)
+            continue
+        r.raise_for_status()
+        try:
+            data = r.json()
+        except ValueError:
+            log.warning("  MktDataConnection %s returned non-JSON — skipping", connector_id)
+            continue
+
+        metadata       = data.get("Metadata") or {}
+        raw_params     = {
+            p["paramName"]: p.get("value", "")
+            for p in (metadata.get("parameters") or [])
+            if p.get("paramName")  # skip malformed entries missing the key name
+        }
+        connector_name = _sanitize_for_log(data.get("MasterLabel", ""))
+        connector_type = _sanitize_for_log(metadata.get("connectorName") or "")
+
+        detail: dict = {
+            "connector_id":   connector_id,
+            "connector_name": connector_name,
+            "connector_type": connector_type,
+            "raw_params":     _redact_params(raw_params),  # never write credentials to disk
+        }
+
+        if connector_type == _CONNECTOR_SNOWFLAKE:
+            account_url_raw = raw_params.get("accountUrl", "")
+            if account_url_raw:
+                # Validate with regex to reject subdomain-bypass attempts
+                # (e.g. host.snowflakecomputing.com.attacker.com.snowflakecomputing.com)
+                if _SNOWFLAKE_ACCT_URL_RE.match(account_url_raw):
+                    _parsed_acct = urlparse(account_url_raw)
+                    hostname = (_parsed_acct.hostname or "").lower()
+                    # Extra guard: hostname must contain snowflakecomputing.com exactly once
+                    if hostname.count("snowflakecomputing.com") == 1:
+                        account_url = _sanitize_for_log(account_url_raw)
+                    else:
+                        log.warning(
+                            "  MktDataConnection %s has suspicious accountUrl %r — ignoring",
+                            connector_id, _sanitize_for_log(account_url_raw),
+                        )
+                        account_url = ""
+                else:
+                    log.warning(
+                        "  MktDataConnection %s has unexpected accountUrl %r — ignoring for routing",
+                        connector_id, _sanitize_for_log(account_url_raw),
+                    )
+                    account_url = ""
+            else:
+                account_url = ""
+            detail["account_url"]        = account_url
+            detail["account_identifier"] = _extract_sf_account_identifier(account_url) if account_url else ""
+            detail["warehouse"]          = _sanitize_for_log(raw_params.get("warehouse", ""))
+            detail["region"]             = _sanitize_for_log(raw_params.get("region", ""))
+            log.debug(
+                "  MktDataConnection %s (%s): account=%s warehouse=%s",
+                connector_id, connector_name,
+                detail["account_identifier"], detail["warehouse"],
+            )
+        else:
+            # Future connector types or external CRM orgs — expose raw_params for routing
+            log.debug(
+                "  MktDataConnection %s (%s type=%s): %d params",
+                connector_id, connector_name, connector_type, len(raw_params),
+            )
+
+        connector_details[connector_id] = detail
+
+    for stream_name, (connector_id, _) in stream_to_connector.items():
+        if connector_id in connector_details:
+            result[stream_name] = connector_details[connector_id]
+
+    log.info(
+        "  Connection details resolved for %d/%d stream(s) (%.1fs)",
+        len(result), len(stream_to_connector), time.monotonic() - t0,
+    )
+    return result
+
+
+# ── Step 3: Fetch MC catalogs ─────────────────────────────────────────────────
+class _CatalogIndex(NamedTuple):
+    """Two-dict index built from a warehouse's MC catalog.
+
+    Separating full-qualified and name-only keys into distinct dicts eliminates
+    any possibility of a collision between the two key types in a shared namespace.
+    """
+    by_full: dict   # {fullTableId.lower() → fullTableId}  — for exact lookups
+    by_name: dict   # {table_name.lower() → fullTableId or list}  — for name-only lookups
+    table_count: int
+
+
+def _fetch_catalog(warehouse_uuid: str, key_id: str, key_secret: str, label: str) -> _CatalogIndex:
+    """
+    Fetch all tables for a warehouse from the MC catalog.
+
+    Returns a _CatalogIndex with two separate lookup dicts:
+      - by_full: keyed by fullTableId.lower() for exact match
+      - by_name: keyed by table name (last segment after final '.'), lowercased
+
+    Both dicts are populated during a single paginated query, scoped to the warehouse UUID
+    to prevent cross-org contamination when multiple warehouses exist in the same MC account.
+
+    Note: for Snowflake warehouses, log a DEBUG sample to confirm the fullTableId format
+    (e.g., "database:schema.table") matches what the Data Stream advancedAttributes provides.
+    """
+    by_full: dict = {}
+    by_name: dict = {}
+    after = None
+    page = 0
+    table_count = 0
+    first_few_logged = False
+
+    while True:
+        page += 1
+        if page > _MAX_PAGES:
+            raise RuntimeError(
+                f"{label} catalog pagination safety limit ({_MAX_PAGES} pages) exceeded."
+            )
+
+        variables: dict = {"dwId": warehouse_uuid}
+        if after:
+            variables["after"] = after
+
+        data = _gql(
+            """
+            query GetAllTables($dwId: UUID, $after: String) {
+              getTables(first: 500, dwId: $dwId, after: $after) {
+                edges { node { fullTableId } }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+            """,
+            key_id,
+            key_secret,
+            variables=variables,
+        )
+
+        result = data.get("getTables") or {}
+        page_fids = []
+        for edge in (result.get("edges") or []):
+            node = edge.get("node") or {}
+            fid = node.get("fullTableId") or ""
+            if not fid:
+                continue
+            by_full[fid.lower()] = fid
+            # Name-only index: last segment after the final '.'
+            if "." in fid:
+                name_only = fid.rsplit(".", 1)[1].lower()
+                if name_only not in by_name:
+                    by_name[name_only] = fid
+                else:
+                    existing = by_name[name_only]
+                    if isinstance(existing, list):
+                        existing.append(fid)
+                    else:
+                        by_name[name_only] = [existing, fid]
+            table_count += 1
+            page_fids.append(fid)
+
+        # Log a sample of raw fullTableId values on the first page at DEBUG level.
+        # This lets operators confirm the key format (e.g. "db:schema.table") matches
+        # what the Data Stream advancedAttributes provides — especially important for Snowflake.
+        if not first_few_logged and page_fids:
+            log.debug("  %s catalog sample fullTableId values: %s", label, page_fids[:5])
+            first_few_logged = True
+
+        log.info("  %s catalog page %d: %d table(s) retrieved so far", label, page, table_count)
+
+        page_info = result.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if not after:
+            log.warning(
+                "  %s catalog hasNextPage=true but endCursor is null — "
+                "stopping pagination to avoid infinite loop",
+                label,
+            )
+            break
+
+    return _CatalogIndex(by_full=by_full, by_name=by_name, table_count=table_count)
+
+
+def _lookup(idx: _CatalogIndex, key: str, label: str) -> Optional[str]:
+    """
+    Look up key in the catalog index, case-insensitively.
+    Tries the full-qualified dict first (exact match), then the name-only dict.
+    Returns fullTableId or None.
+    Warns and returns the first entry when a name-only key is ambiguous.
+    """
+    lower = key.lower()
+    # Prefer exact full-qualified match
+    result = idx.by_full.get(lower)
+    if result is not None:
+        return result
+    # Fall back to name-only match
+    entry = idx.by_name.get(lower)
+    if entry is None:
+        return None
+    if isinstance(entry, list):
+        log.warning(
+            "  Ambiguous catalog match for '%s' in %s — multiple tables share this name: %s. "
+            "Using '%s'. Provide the full-qualified key (database:schema.table) to be precise.",
+            key, label, entry, entry[0],
+        )
+        return entry[0]
+    return entry
+
+
+# ── Step 4: Resolve edges from Data Streams ───────────────────────────────────
+def resolve_edges(
+    streams: list,
+    dc_idx: _CatalogIndex,
+    crm_idx: Optional[_CatalogIndex],
+    sf_idx: Optional[_CatalogIndex],
+    dc_warehouse_uuid: str,
+    crm_warehouse_uuid: Optional[str],
+    snowflake_warehouse_uuid: Optional[str],
+    connection_details: Optional[dict] = None,
+    sf_catalogs: Optional[dict] = None,
+    crm_catalogs: Optional[dict] = None,
+) -> tuple:
+    """
+    Match each data stream's source table and DLO to MC catalog entries.
+
+    Returns (edges, skipped) where:
+      edges   — list of edge dicts ready for the GraphQL push
+      skipped — list of dicts with full raw stream data + skip reason for every
+                stream that could not be resolved; saved to disk for future
+                troubleshooting and manual MC asset mapping
+
+    Multi-warehouse Snowflake:
+      sf_catalogs  — {account_identifier: (_CatalogIndex, warehouse_uuid)} built
+                     from MCD_SNOWFLAKE_WAREHOUSE_MAP + connection_details
+      connection_details — {stream_name: {account_url, account_identifier, connector_id, ...}}
+                           from fetch_connection_details(); used to route each
+                           Snowflake or linked-CRM stream to the right catalog entry
+      sf_idx / snowflake_warehouse_uuid — single-warehouse fallback when sf_catalogs
+                                          has no entry for a stream's account
+
+    Multi-org CRM:
+      crm_catalogs — {connector_id: (_CatalogIndex, warehouse_uuid)} built from
+                     MCD_CRM_WAREHOUSE_MAP; keyed by DataConnectorId so each linked
+                     CRM org routes to the correct MC CRM warehouse.
+                     Native same-org streams (no MktDataConnection record) have no
+                     connector_id in connection_details and fall back to crm_idx.
+
+    Edge dict schema:
+      {
+        "source_full_id":   str,   fullTableId of source in MC catalog
+        "source_warehouse": str,   MC warehouse UUID for source system
+        "dest_full_id":     str,   fullTableId of DLO in MC Data Cloud catalog
+        "dest_warehouse":   str,   DC warehouse UUID
+        "connector_type":   str,   SalesforceDotCom | SNOWFLAKE
+        "dlo_name":         str,   raw DLO name from Salesforce
+        "source_label":     str,   human-readable source description for logging
+      }
+
+    Unsupported connector types (AwsS3 and others) are skipped with a warning.
+    AwsS3 sources require custom node creation before edges can be linked — that
+    workflow is intentionally out of scope for this script.
+    """
+    t0 = time.monotonic()
+    log.info("Step 4: Resolving %d data stream(s) to MC catalog entries", len(streams))
+    edges: list = []
+    skipped: list = []           # full raw stream + reason, saved to disk at end
+    skipped_bad_data = 0         # missing required field in API response
+    skipped_missing_uuid = 0     # connector type present but warehouse UUID not configured
+    skipped_unknown_connector = 0
+    skipped_not_in_mc = 0        # table not found in MC catalog after lookup
+
+    _conn_details  = connection_details or {}
+    _sf_catalogs   = sf_catalogs or {}
+    _crm_catalogs  = crm_catalogs or {}
+
+    def _skip(stream: dict, reason: str, detail: str = "") -> None:
+        """Record a skipped stream with full DSO + connection details for troubleshooting."""
+        stream_name_key = stream.get("name", "")
+        stream_name     = _sanitize_for_log(stream_name_key)
+        conn_info       = _conn_details.get(stream_name_key, {})
+        skipped.append({
+            "reason":             reason,
+            "detail":             detail,
+            "connector_type":     _sanitize_for_log(
+                (stream.get("connectorInfo") or {}).get("connectorType", "unknown")
+            ),
+            "dlo_name":           _sanitize_for_log(
+                (stream.get("dataLakeObjectInfo") or {}).get("name", "unknown")
+            ),
+            "connection_details": conn_info,   # Snowflake account URL, warehouse, region
+            "raw_stream":         _sanitize_stream_for_disk(stream),  # credentials redacted
+        })
+
+    for stream in streams:
+        connector_info = stream.get("connectorInfo") or {}
+        connector_type = _sanitize_for_log(connector_info.get("connectorType", ""))
+        dlo_info = stream.get("dataLakeObjectInfo") or {}
+        dlo_name = _sanitize_for_log(dlo_info.get("name", ""))
+
+        if not dlo_name:
+            log.warning(
+                "  Stream (connectorType=%s) has no dataLakeObjectInfo.name — skipping",
+                connector_type,
+            )
+            _skip(stream, "missing_dlo_name")
+            skipped_bad_data += 1
+            continue
+
+        if connector_type not in _SUPPORTED_CONNECTORS:
+            log.warning(
+                "  Unsupported connector type '%s' (DLO=%s) — skipping. "
+                "Supported: %s",
+                connector_type, dlo_name, ", ".join(sorted(_SUPPORTED_CONNECTORS)),
+            )
+            _skip(stream, "unsupported_connector", f"connector_type={connector_type}")
+            skipped_unknown_connector += 1
+            continue
+
+        # Resolve DLO in Data Cloud catalog
+        dlo_full_id = _lookup(dc_idx, dlo_name, "Data Cloud")
+        if not dlo_full_id:
+            log.warning(
+                "  DLO '%s' not found in MC Data Cloud catalog — skipping. "
+                "Trigger a metadata sync in Monte Carlo to pick up this table.",
+                dlo_name,
+            )
+            _skip(stream, "dlo_not_in_mc_catalog", f"dlo_name={dlo_name}")
+            skipped_not_in_mc += 1
+            continue
+
+        # Resolve source table based on connector type
+        if connector_type == _CONNECTOR_SFDC:
+            # Route to the correct MC CRM warehouse.
+            # Priority: crm_catalogs (multi-org map keyed by connector_id) → crm_idx (fallback).
+            # Native same-org CRM streams have no MktDataConnection record, so connector_id
+            # is absent from connection_details; they always fall back to crm_idx.
+            stream_name_crm  = _sanitize_for_log(stream.get("name", ""))
+            conn_info_crm    = _conn_details.get(stream_name_crm, {})
+            connector_id_crm = conn_info_crm.get("connector_id", "")
+            # crm_catalogs keys are lowercased by _parse_warehouse_map; Salesforce IDs
+            # are case-insensitive, so normalise before lookup.
+            connector_id_crm_key = connector_id_crm.lower()
+
+            active_crm_idx: Optional[_CatalogIndex] = None
+            active_crm_uuid: Optional[str] = None
+
+            if connector_id_crm_key and connector_id_crm_key in _crm_catalogs:
+                active_crm_idx, active_crm_uuid = _crm_catalogs[connector_id_crm_key]
+                log.debug(
+                    "  Routed CRM stream '%s' to warehouse %s via connector_id '%s'",
+                    stream_name_crm, active_crm_uuid, connector_id_crm,
+                )
+            elif crm_idx is not None:
+                # If this stream has a resolved connector_id but it's not in the map,
+                # it is a linked external org. Routing it to the native-org fallback
+                # warehouse would silently look in the wrong catalog — skip instead.
+                if connector_id_crm_key and _crm_catalogs:
+                    _safe_conn_id = _sanitize_for_log(connector_id_crm)
+                    log.warning(
+                        "  CRM stream '%s' (connector_id=%s) is a linked-org stream not found "
+                        "in MCD_CRM_WAREHOUSE_MAP — skipping to avoid wrong-warehouse routing. "
+                        "Add '%s=<uuid>' to MCD_CRM_WAREHOUSE_MAP.",
+                        stream_name_crm, _safe_conn_id, _safe_conn_id,
+                    )
+                    _skip(stream, "linked_crm_org_not_in_warehouse_map",
+                          f"connector_id={connector_id_crm} dlo_name={dlo_name}")
+                    skipped_missing_uuid += 1
+                    continue
+                active_crm_idx  = crm_idx
+                active_crm_uuid = crm_warehouse_uuid
+            else:
+                log.warning(
+                    "  CRM stream found (DLO=%s) but no CRM warehouse is configured — skipping. "
+                    "Set MCD_CRM_WAREHOUSE_UUID or MCD_CRM_WAREHOUSE_MAP to enable CRM→DLO lineage.",
+                    dlo_name,
+                )
+                _skip(stream, "crm_warehouse_uuid_not_configured", f"dlo_name={dlo_name}")
+                skipped_missing_uuid += 1
+                continue
+
+            if active_crm_uuid is None:
+                raise RuntimeError(
+                    "Internal invariant violated: active_crm_idx is set but active_crm_uuid is None. "
+                    "This is a bug — please report it."
+                )
+
+            details = connector_info.get("connectorDetails") or {}
+            source_obj = _sanitize_for_log(details.get("sourceObject", ""))
+            if not source_obj:
+                log.warning(
+                    "  CRM stream for DLO=%s has no connectorDetails.sourceObject — skipping",
+                    dlo_name,
+                )
+                _skip(stream, "missing_crm_source_object", f"dlo_name={dlo_name}")
+                skipped_bad_data += 1
+                continue
+            src_full_id = _lookup(active_crm_idx, source_obj, "Salesforce CRM")
+            if not src_full_id:
+                log.warning(
+                    "  CRM table '%s' not found in MC CRM catalog (DLO=%s) — skipping. "
+                    "Confirm the Salesforce CRM connector has synced this object.",
+                    source_obj, dlo_name,
+                )
+                _skip(stream, "source_not_in_mc_catalog",
+                      f"source_object={source_obj} dlo_name={dlo_name}")
+                skipped_not_in_mc += 1
+                continue
+            src_warehouse_uuid = active_crm_uuid
+            source_label = f"CRM:{source_obj}"
+
+        else:  # SNOWFLAKE
+            # Route to the correct MC warehouse using the stream's Snowflake account identifier.
+            # Priority: sf_catalogs (multi-warehouse map) → sf_idx (single-warehouse fallback).
+            stream_name  = _sanitize_for_log(stream.get("name", ""))
+            conn_info    = _conn_details.get(stream_name, {})
+            account_id   = conn_info.get("account_identifier", "")
+            account_url  = conn_info.get("account_url", "")
+
+            active_sf_idx: Optional[_CatalogIndex] = None
+            active_sf_uuid: Optional[str] = None
+
+            if account_id and account_id in _sf_catalogs:
+                active_sf_idx, active_sf_uuid = _sf_catalogs[account_id]
+                log.debug(
+                    "  Routed stream '%s' to warehouse %s via account '%s'",
+                    stream_name, active_sf_uuid, account_id,
+                )
+            elif sf_idx is not None:
+                # Fall back to single-warehouse mode
+                active_sf_idx  = sf_idx
+                active_sf_uuid = snowflake_warehouse_uuid
+                if account_id:
+                    log.warning(
+                        "  Snowflake stream '%s' (account=%s) not in warehouse map — "
+                        "falling back to MCD_SNOWFLAKE_WAREHOUSE_UUID. "
+                        "Add '%s=<uuid>' to MCD_SNOWFLAKE_WAREHOUSE_MAP for precise routing.",
+                        stream_name, account_id, account_id,
+                    )
+            else:
+                if _sf_catalogs and account_id:
+                    log.warning(
+                        "  Snowflake stream '%s' (DLO=%s, account=%s) not in MCD_SNOWFLAKE_WAREHOUSE_MAP "
+                        "and no fallback UUID set. Add '%s=<uuid>' to MCD_SNOWFLAKE_WAREHOUSE_MAP.",
+                        stream_name, dlo_name, account_id, account_id,
+                    )
+                else:
+                    log.warning(
+                        "  Snowflake stream found (DLO=%s, account=%s) but no warehouse is configured. "
+                        "Set MCD_SNOWFLAKE_WAREHOUSE_UUID or MCD_SNOWFLAKE_WAREHOUSE_MAP.",
+                        dlo_name, account_id or "unknown",
+                    )
+                _skip(stream, "snowflake_warehouse_not_configured",
+                      f"dlo_name={dlo_name} account_identifier={account_id} account_url={account_url}")
+                skipped_missing_uuid += 1
+                continue
+
+            if active_sf_uuid is None:
+                log.warning(
+                    "  Snowflake stream '%s' (DLO=%s): warehouse catalog resolved but "
+                    "warehouse UUID is None — skipping. "
+                    "Verify MCD_SNOWFLAKE_WAREHOUSE_UUID is set.",
+                    stream_name, dlo_name,
+                )
+                _skip(stream, "snowflake_warehouse_uuid_none",
+                      f"dlo_name={dlo_name} account_identifier={account_id}")
+                skipped_missing_uuid += 1
+                continue
+
+            attrs = stream.get("advancedAttributes") or {}
+            sf_db     = _sanitize_for_log(attrs.get("database", "")).lower()
+            sf_schema = _sanitize_for_log(attrs.get("schema", "")).lower()
+            sf_obj    = _sanitize_for_log(attrs.get("object", "")).lower()
+            if not sf_obj:
+                log.warning(
+                    "  Snowflake stream for DLO=%s has no advancedAttributes.object — skipping",
+                    dlo_name,
+                )
+                _skip(stream, "missing_snowflake_object",
+                      f"dlo_name={dlo_name} advancedAttributes={str(_redact_params(dict(attrs)))[:500]}")
+                skipped_bad_data += 1
+                continue
+            # Try full-qualified key first (most specific), then object name only (fallback).
+            sf_key_full = f"{sf_db}:{sf_schema}.{sf_obj}" if sf_db and sf_schema else None
+            src_full_id = None
+            if sf_key_full:
+                src_full_id = _lookup(active_sf_idx, sf_key_full, "Snowflake")
+            if src_full_id is None:
+                src_full_id = _lookup(active_sf_idx, sf_obj, "Snowflake")
+                if src_full_id is not None:
+                    log.warning(
+                        "  Snowflake full-qualified key '%s' not found in catalog; "
+                        "matched by table name only ('%s'). "
+                        "Run with LOG_LEVEL=DEBUG to verify the fullTableId format.",
+                        sf_key_full or sf_obj, sf_obj,
+                    )
+            if not src_full_id:
+                log.warning(
+                    "  Snowflake table '%s.%s.%s' not found in MC catalog (DLO=%s, account=%s) — skipping. "
+                    "Run with LOG_LEVEL=DEBUG to inspect catalog fullTableId format.",
+                    sf_db.upper(), sf_schema.upper(), sf_obj.upper(), dlo_name,
+                    account_id or "unknown",
+                )
+                _skip(stream, "source_not_in_mc_catalog",
+                      f"sf_key={sf_key_full} dlo_name={dlo_name} "
+                      f"account_identifier={account_id} "
+                      f"advancedAttributes={str(_redact_params(dict(attrs)))[:500]}")
+                skipped_not_in_mc += 1
+                continue
+            src_warehouse_uuid = active_sf_uuid
+            source_label = f"Snowflake:{sf_db.upper()}.{sf_schema.upper()}.{sf_obj.upper()}"
+
+        edges.append({
+            "source_full_id":   src_full_id,
+            "source_warehouse": src_warehouse_uuid,
+            "dest_full_id":     dlo_full_id,
+            "dest_warehouse":   dc_warehouse_uuid,
+            "connector_type":   connector_type,
+            "dlo_name":         dlo_name,
+            "source_label":     source_label,
+        })
+        log.debug("  Resolved: %s → %s", source_label, dlo_name)
+
+    log.info(
+        "  %d edge(s) resolved; %d skipped (not in MC catalog); "
+        "%d skipped (warehouse UUID not configured); "
+        "%d skipped (unsupported connector); %d skipped (bad API data) (%.1fs)",
+        len(edges), skipped_not_in_mc, skipped_missing_uuid,
+        skipped_unknown_connector, skipped_bad_data,
+        time.monotonic() - t0,
+    )
+    return edges, skipped
+
+
+# ── Failed-edge persistence ───────────────────────────────────────────────────
+def _save_failed_edges(run_id: str, edges: list) -> str:
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = Path(__file__).parent / f"failed_edges_external_{run_id}_{ts}.json"
+    content = json.dumps(edges, indent=2).encode()
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        written = os.write(fd, content)
+        if written != len(content):
+            raise OSError(f"Partial write: wrote {written}/{len(content)} bytes")
+    except BaseException:
+        os.close(fd)
+        path.unlink(missing_ok=True)  # don't leave a zero-byte file that blocks retry
+        raise
+    else:
+        os.close(fd)
+    log.info("  Failed edges saved to: %s", path.resolve())
+    return str(path)
+
+
+def _save_skipped_streams(run_id: str, skipped: list) -> str:
+    """
+    Save full raw DSO data for every stream that could not be resolved to an MC
+    lineage edge.  Each entry includes:
+      - reason          why it was skipped (e.g. "source_not_in_mc_catalog")
+      - detail          human-readable detail string
+      - connector_type  Salesforce connector type string
+      - dlo_name        the DLO the stream feeds
+      - raw_stream      complete API response object — includes connectorInfo,
+                        advancedAttributes, dataLakeObjectInfo etc.  Use this to
+                        manually identify the MC asset and create the edge later,
+                        or to diagnose why the lookup failed.
+    """
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = Path(__file__).parent / f"skipped_streams_{run_id}_{ts}.json"
+    payload = {
+        "run_id":        run_id,
+        "timestamp_utc": ts,
+        "skipped_count": len(skipped),
+        "streams":       skipped,
+    }
+    content = json.dumps(payload, indent=2, default=str).encode()
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        written = os.write(fd, content)
+        if written != len(content):
+            raise OSError(f"Partial write: wrote {written}/{len(content)} bytes")
+    except BaseException:
+        os.close(fd)
+        path.unlink(missing_ok=True)
+        raise
+    else:
+        os.close(fd)
+    return str(path.resolve())
+
+
+# ── Discovery mode ────────────────────────────────────────────────────────────
+def _run_discover(streams: list, run_id: str, instance_url: str) -> None:
+    """
+    Group all data streams by connector type and print a summary table.
+    Saves raw connection field samples to discover_{run_id}_{ts}.json.
+    Does not touch the MC catalog or push any lineage.
+    """
+    t0 = time.monotonic()
+    log.info("=== Discovery Mode — scanning %d stream(s) ===", len(streams))
+
+    groups: dict = {}
+    for stream in streams:
+        ct = (stream.get("connectorInfo") or {}).get("connectorType", "(unknown)")
+        if ct not in groups:
+            groups[ct] = []
+        groups[ct].append(stream)
+
+    report_types: dict = {}
+    for ct, group_streams in sorted(groups.items()):
+        sample = group_streams[0]
+        # Redact connectorDetails and advancedAttributes — may contain credentials.
+        # isinstance guards handle unexpected non-dict values from the API without crashing.
+        _sample_conn_info = dict(sample.get("connectorInfo") or {})
+        if "connectorDetails" in _sample_conn_info:
+            cd = _sample_conn_info.get("connectorDetails")
+            _sample_conn_info["connectorDetails"] = _redact_params(cd if isinstance(cd, dict) else {})
+        _sample_aa = sample.get("advancedAttributes")
+        report_types[ct] = {
+            "count":                  len(group_streams),
+            "supported_for_lineage":  ct in _SUPPORTED_CONNECTORS,
+            "dlo_names": [
+                _sanitize_for_log(
+                    (s.get("dataLakeObjectInfo") or {}).get("name", "(unknown)")
+                )
+                for s in group_streams
+            ],
+            "sample_connector_info":        _sample_conn_info,
+            "sample_advanced_attributes":   _redact_params(_sample_aa if isinstance(_sample_aa, dict) else {}),
+            "sample_dlo_info":              sample.get("dataLakeObjectInfo") or {},
+        }
+
+    log.info("  %-32s  %5s  %s", "Connector Type", "Count", "Lineage Support")
+    log.info("  %s", "-" * 62)
+    for ct, info in sorted(report_types.items()):
+        if ct == _CONNECTOR_SFDC:
+            support = "Yes — CRM → DLO"
+        elif ct == _CONNECTOR_SNOWFLAKE:
+            support = "Yes — Snowflake → DLO"
+        else:
+            support = "No — not supported"
+        log.info("  %-32s  %5d  %s", ct, info["count"], support)
+    log.info("  Total: %d stream(s) across %d connector type(s)", len(streams), len(report_types))
+
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = Path(__file__).parent / f"discover_{run_id}_{ts}.json"
+    payload = {
+        "run_id":         run_id,
+        "timestamp_utc":  ts,
+        "instance_url":   instance_url,
+        "total_streams":  len(streams),
+        "connector_types": report_types,
+    }
+    content = json.dumps(payload, indent=2, default=str).encode()
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        written = os.write(fd, content)
+        if written != len(content):
+            raise OSError(f"Partial write: wrote {written}/{len(content)} bytes")
+    except BaseException:
+        os.close(fd)
+        path.unlink(missing_ok=True)
+        raise
+    else:
+        os.close(fd)
+
+    log.info(
+        "  Full connection field samples saved to: %s (%.1fs)",
+        path.resolve(), time.monotonic() - t0,
+    )
+
+
+# ── Step 4: GraphQL mutations ─────────────────────────────────────────────────
+_CREATE_EDGE_MUTATION = """
+mutation CreateEdge($source: NodeInput!, $destination: NodeInput!) {
+  createOrUpdateLineageEdge(source: $source, destination: $destination) {
+    edge {
+      source { mcon objectType }
+      destination { mcon objectType }
+    }
+  }
+}
+"""
+
+
+def _is_push_retryable(exc: BaseException) -> bool:
+    # GraphQL application errors (MCGraphQLError) are permanent — never retry.
+    if isinstance(exc, MCGraphQLError):
+        return False
+    # Suppress retry on HTTP 4xx (won't resolve on retry).
+    resp = getattr(exc, "response", None)
+    if resp is not None and 400 <= resp.status_code < 500:
+        return False
+    return True
+
+
+@retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=2, min=2, max=60),
+    retry=retry_if_exception(_is_push_retryable),
+    reraise=True,
+)
+def _push_one_edge(
+    source_node: dict,
+    dest_node: dict,
+    key_id: str,
+    key_secret: str,
+) -> dict:
+    return _gql(
+        _CREATE_EDGE_MUTATION,
+        key_id,
+        key_secret,
+        variables={"source": source_node, "destination": dest_node},
+    )
+
+
+def push_edges(
+    edges: list,
+    key_id: str,
+    key_secret: str,
+    run_id: str,
+    shutdown_flag: Optional[threading.Event] = None,
+) -> int:
+    """
+    Push all resolved edges one at a time via createOrUpdateLineageEdge mutation.
+    The mutation is idempotent — re-running is safe.
+    Returns count of successfully pushed edges.
+    Saves any failed edges to a local JSON file for retry.
+    Stops cleanly if shutdown_flag is set (SIGTERM).
+    """
+    t0 = time.monotonic()
+    log.info("Step 5: Pushing %d edge(s) via GraphQL mutation", len(edges))
+    pushed = 0
+    failures: list = []
+
+    for i, edge in enumerate(edges, 1):
+        if shutdown_flag is not None and shutdown_flag.is_set():
+            log.warning(
+                "SIGTERM received — stopping push after %d/%d edges. "
+                "Partial results have been written to Monte Carlo. Re-run is safe (idempotent).",
+                i - 1, len(edges),
+            )
+            break
+        source_node = {
+            "objectType": "TABLE",
+            "objectId":   edge["source_full_id"],
+            "resourceId": edge["source_warehouse"],
+        }
+        dest_node = {
+            "objectType": "TABLE",
+            "objectId":   edge["dest_full_id"],
+            "resourceId": edge["dest_warehouse"],
+        }
+        try:
+            result = _push_one_edge(source_node, dest_node, key_id, key_secret)
+            pushed += 1
+            edge_result = (result.get("createOrUpdateLineageEdge") or {}).get("edge") or {}
+            src_mcon = (edge_result.get("source") or {}).get("mcon", "?")
+            dst_mcon = (edge_result.get("destination") or {}).get("mcon", "?")
+            log.info("  [%d/%d] Pushed: %s → %s", i, len(edges), edge["source_label"], edge["dlo_name"])
+            log.debug("    src_mcon=%s  dst_mcon=%s", src_mcon, dst_mcon)
+        except Exception as exc:
+            log.error(
+                "  [%d/%d] Failed to push %s → %s: %s",
+                i, len(edges), edge["source_label"], edge["dlo_name"], exc,
+            )
+            failures.append(edge)
+
+    if failures:
+        try:
+            path = _save_failed_edges(run_id, failures)
+            log.error(
+                "%d edge(s) failed to push. Re-run after addressing errors. "
+                "Failed edges saved to: %s",
+                len(failures), path,
+            )
+        except OSError as exc:
+            summary = [
+                {"connector_type": e["connector_type"], "dlo_name": e["dlo_name"]}
+                for e in failures
+            ]
+            log.error(
+                "%d edge(s) failed to push and the failed-edge file could not be written (%s). "
+                "Failed edges (connector_type, dlo_name): %s",
+                len(failures), exc, json.dumps(summary)[:2000],
+            )
+
+    log.info(
+        "  Push complete: %d succeeded, %d failed (%.1fs)",
+        pushed, len(failures), time.monotonic() - t0,
+    )
+    return pushed
+
+
+# ── Service classes ───────────────────────────────────────────────────────────
+class SalesforceService:
+    def __init__(self, instance_url: str, client_id: str, client_secret: str) -> None:
+        self.instance_url = instance_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._token: str = ""
+
+    def __repr__(self) -> str:
+        return (
+            f"SalesforceService(instance_url={self.instance_url!r}, "
+            f"client_id={self.client_id!r}, client_secret=<redacted>)"
+        )
+
+    def authenticate(self) -> None:
+        self._token = get_sf_token(self.instance_url, self.client_id, self.client_secret)
+        self.client_secret = ""  # drop reference after use
+
+    @property
+    def token(self) -> str:
+        if not self._token:
+            raise RuntimeError("Not authenticated — call authenticate() first.")
+        return self._token
+
+    def fetch_data_streams(self) -> list:
+        return fetch_data_streams(self.instance_url, self.token)
+
+    def fetch_connection_details(self, streams: list) -> dict:
+        return fetch_connection_details(self.instance_url, self.token, streams)
+
+
+class MCLineageService:
+    def __init__(self, key_id: str, key_secret: str) -> None:
+        self.key_id = key_id
+        self.key_secret = key_secret
+
+    def fetch_catalog(self, warehouse_uuid: str, label: str) -> _CatalogIndex:
+        return _fetch_catalog(warehouse_uuid, self.key_id, self.key_secret, label)
+
+    def push_edges(
+        self,
+        edges: list,
+        run_id: str,
+        shutdown_flag: Optional[threading.Event] = None,
+    ) -> int:
+        return push_edges(edges, self.key_id, self.key_secret, run_id, shutdown_flag)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main() -> None:
+    run_id = uuid_module.uuid4().hex[:8]
+    global log
+    log = _setup_logging(run_id)
+
+    parser = argparse.ArgumentParser(
+        description="Push Salesforce Data 360 external source → DLO lineage to Monte Carlo"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch live data and preview edges, but skip the MC push",
+    )
+    parser.add_argument(
+        "--discover",
+        action="store_true",
+        help=(
+            "Scan all Data Streams and print a connector-type summary. "
+            "Saves raw connectorInfo + advancedAttributes samples to "
+            "discover_{run_id}_{ts}.json. Does not fetch the MC catalog or push lineage."
+        ),
+    )
+    args = parser.parse_args()
+
+    _shutdown_requested = threading.Event()
+
+    def _handle_sigterm(signum, frame):  # noqa: ANN001
+        log.warning(
+            "Received SIGTERM — stop requested. "
+            "Push will halt cleanly after the current edge. Re-run is safe (idempotent)."
+        )
+        _shutdown_requested.set()
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+    mode_tag = " [DISCOVER]" if args.discover else " [DRY RUN]" if args.dry_run else ""
+    log.info(
+        "=== Data 360 External Lineage Push | run_id=%s%s ===",
+        run_id, mode_tag,
+    )
+    t_start = time.monotonic()
+
+    # MC creds — validate at startup (before any Salesforce API calls) so a misconfigured
+    # run fails immediately rather than after expensive data collection.
+    # Skipped in --discover mode which doesn't need MC credentials.
+    if not args.discover:
+        mcd_id    = _require("MCD_ID")
+        mcd_token = _require("MCD_TOKEN")
+        # Accept MCD_RESOURCE_UUID as an alias for MCD_DC_WAREHOUSE_UUID so that
+        # users running both scripts from the same .env only need to set one variable.
+        dc_warehouse_uuid = (
+            os.environ.get("MCD_DC_WAREHOUSE_UUID")
+            or os.environ.get("MCD_RESOURCE_UUID")
+            or ""
+        )
+        if not dc_warehouse_uuid:
+            log.error(
+                "Required environment variable 'MCD_DC_WAREHOUSE_UUID' is not set. "
+                "Also accepted as 'MCD_RESOURCE_UUID' (shared with push_lineage.py). "
+                "Find the UUID in Monte Carlo: Settings → Integrations → your Data Cloud connection."
+            )
+            sys.exit(1)
+        _validate_uuid("MCD_DC_WAREHOUSE_UUID", dc_warehouse_uuid)
+
+        crm_warehouse_uuid       = os.environ.get("MCD_CRM_WAREHOUSE_UUID")
+        crm_warehouse_map_raw    = os.environ.get("MCD_CRM_WAREHOUSE_MAP", "")
+        snowflake_warehouse_uuid = os.environ.get("MCD_SNOWFLAKE_WAREHOUSE_UUID")
+        snowflake_warehouse_map  = os.environ.get("MCD_SNOWFLAKE_WAREHOUSE_MAP", "")
+        if crm_warehouse_uuid:
+            _validate_uuid("MCD_CRM_WAREHOUSE_UUID", crm_warehouse_uuid)
+        if snowflake_warehouse_uuid:
+            _validate_uuid("MCD_SNOWFLAKE_WAREHOUSE_UUID", snowflake_warehouse_uuid)
+
+        crm_warehouse_map: dict = {}
+        if crm_warehouse_map_raw:
+            crm_warehouse_map = _parse_warehouse_map(crm_warehouse_map_raw)
+            for conn_id, wh_uuid in crm_warehouse_map.items():
+                _validate_uuid(f"MCD_CRM_WAREHOUSE_MAP[{conn_id}]", wh_uuid)
+            log.info("  CRM warehouse map: %d connector(s) configured", len(crm_warehouse_map))
+
+        sf_warehouse_map: dict = {}
+        if snowflake_warehouse_map:
+            sf_warehouse_map = _parse_warehouse_map(snowflake_warehouse_map)
+            for acct_id, wh_uuid in sf_warehouse_map.items():
+                _validate_uuid(f"MCD_SNOWFLAKE_WAREHOUSE_MAP[{acct_id}]", wh_uuid)
+            log.info("  Snowflake warehouse map: %d account(s) configured", len(sf_warehouse_map))
+
+    # Salesforce creds — required for all modes including --discover
+    sf_instance_url  = _require("SF_ORG_URL")
+    sf_client_id     = _require("SF_CLIENT_ID")
+    sf_client_secret = _require("SF_CLIENT_SECRET")
+
+    # SSRF guard: SF_ORG_URL must be HTTPS and must not resolve to a private/loopback IP
+    _parsed_url = urlparse(sf_instance_url)
+    if _parsed_url.scheme != "https" or not _parsed_url.hostname or "@" in (_parsed_url.netloc or ""):
+        log.error(
+            "SF_ORG_URL is not a valid HTTPS URL (got: %s). "
+            "Expected format: https://myorg.my.salesforce.com",
+            sf_instance_url,
+        )
+        sys.exit(1)
+    if _parsed_url.path not in ("", "/"):
+        log.error(
+            "SF_ORG_URL must not contain a path component (got: %r). "
+            "Expected format: https://myorg.my.salesforce.com",
+            sf_instance_url,
+        )
+        sys.exit(1)
+    try:
+        _sf_addr = ipaddress.ip_address(_parsed_url.hostname)
+        if (_sf_addr.is_private or _sf_addr.is_loopback or _sf_addr.is_link_local
+                or _sf_addr.is_reserved or _sf_addr.is_multicast):
+            log.error(
+                "SF_ORG_URL hostname is a private/loopback IP (%s) — refusing to connect. "
+                "SF_ORG_URL must be a Salesforce My Domain URL, not an internal address.",
+                _parsed_url.hostname,
+            )
+            sys.exit(1)
+    except ValueError:
+        pass  # hostname is a domain name — IP-based SSRF check not applicable
+
+    sf_svc = SalesforceService(sf_instance_url, sf_client_id, sf_client_secret)
+
+    # Pre-initialize so references outside the try block are always defined
+    streams: list = []
+    edges: list = []
+    skipped: list = []
+
+    try:
+        # Step 1
+        sf_svc.authenticate()
+
+        # Step 2
+        streams = sf_svc.fetch_data_streams()
+
+        # --discover: print connector-type summary and exit; no MC creds needed
+        if args.discover:
+            _run_discover(streams, run_id, sf_instance_url)
+            sys.exit(0)
+
+        if not streams:
+            log.warning("No data streams returned from Salesforce — nothing to push.")
+            sys.exit(0)
+
+        mc_svc = MCLineageService(mcd_id, mcd_token)
+
+        connector_types_present = {
+            (s.get("connectorInfo") or {}).get("connectorType", "") for s in streams
+        }
+        log.info(
+            "  Connector types present in streams: %s",
+            ", ".join(sorted(ct for ct in connector_types_present if ct)) or "none",
+        )
+
+        need_crm = _CONNECTOR_SFDC in connector_types_present
+        need_sf  = _CONNECTOR_SNOWFLAKE in connector_types_present
+
+        # Step 2b: Fetch connection details for all streams via MktDataConnection.
+        # Covers Snowflake (account routing) and any future connector types.
+        # Native same-org CRM connections will not have a MktDataConnection record
+        # and are silently omitted.
+        connection_details: dict = {}
+        try:
+            connection_details = sf_svc.fetch_connection_details(streams)
+        except Exception as exc:
+            if (need_sf and sf_warehouse_map) or (need_crm and crm_warehouse_map):
+                log.error(
+                    "  fetch_connection_details failed (%s). "
+                    "Multi-warehouse routing is disabled — streams will fall back to single-UUID "
+                    "config or be skipped entirely. This may produce incorrect lineage when "
+                    "multiple CRM orgs or Snowflake accounts are in use. "
+                    "Resolve the error above and re-run before pushing to production.",
+                    exc,
+                )
+            else:
+                log.warning(
+                    "  Could not fetch connection details (%s). "
+                    "Snowflake routing uses single-UUID fallback.",
+                    exc,
+                )
+
+        # Step 3: Fetch catalogs for the warehouses we need
+        t3 = time.monotonic()
+        log.info("Step 3: Fetching MC catalog(s)")
+        dc_idx = mc_svc.fetch_catalog(dc_warehouse_uuid, "Data Cloud")
+
+        crm_idx: Optional[_CatalogIndex] = None
+        crm_catalogs_built: dict = {}
+        if need_crm:
+            if crm_warehouse_map:
+                for conn_id, wh_uuid in crm_warehouse_map.items():
+                    label = f"Salesforce CRM(connector={conn_id})"
+                    catalog = mc_svc.fetch_catalog(wh_uuid, label)
+                    crm_catalogs_built[conn_id] = (catalog, wh_uuid)
+            if crm_warehouse_uuid:
+                crm_idx = mc_svc.fetch_catalog(crm_warehouse_uuid, "Salesforce CRM")
+            elif not crm_warehouse_map:
+                log.warning(
+                    "  CRM streams detected but neither MCD_CRM_WAREHOUSE_UUID nor "
+                    "MCD_CRM_WAREHOUSE_MAP is set. CRM→DLO edges will be skipped."
+                )
+
+        # Build sf_catalogs: {account_identifier → (_CatalogIndex, warehouse_uuid)}
+        # Covers all accounts referenced in the warehouse map.
+        sf_idx: Optional[_CatalogIndex] = None
+        sf_catalogs: dict = {}
+        if need_sf:
+            if sf_warehouse_map:
+                for acct_id, wh_uuid in sf_warehouse_map.items():
+                    label = f"Snowflake({acct_id})"
+                    catalog = mc_svc.fetch_catalog(wh_uuid, label)
+                    sf_catalogs[acct_id] = (catalog, wh_uuid)
+            if snowflake_warehouse_uuid and not sf_warehouse_map:
+                # Single-warehouse fallback — also pre-fetch for any unmapped streams
+                sf_idx = mc_svc.fetch_catalog(snowflake_warehouse_uuid, "Snowflake")
+            elif snowflake_warehouse_uuid:
+                # Both map and fallback set — fetch fallback catalog too
+                sf_idx = mc_svc.fetch_catalog(snowflake_warehouse_uuid, "Snowflake (fallback)")
+            elif not sf_warehouse_map:
+                log.warning(
+                    "  Snowflake streams detected but neither MCD_SNOWFLAKE_WAREHOUSE_UUID "
+                    "nor MCD_SNOWFLAKE_WAREHOUSE_MAP is set. Snowflake→DLO edges will be skipped."
+                )
+
+        log.info("  Step 3 complete (%.1fs)", time.monotonic() - t3)
+
+        # Step 4
+        edges, skipped = resolve_edges(
+            streams=streams,
+            dc_idx=dc_idx,
+            crm_idx=crm_idx,
+            sf_idx=sf_idx,
+            dc_warehouse_uuid=dc_warehouse_uuid,
+            crm_warehouse_uuid=crm_warehouse_uuid,
+            snowflake_warehouse_uuid=snowflake_warehouse_uuid,
+            connection_details=connection_details,
+            sf_catalogs=sf_catalogs,
+            crm_catalogs=crm_catalogs_built,
+        )
+
+        # Deduplicate: multiple Data Streams can share the same source→DLO pair
+        seen_pairs: set = set()
+        deduped: list = []
+        for _e in edges:
+            _pair = (_e["source_full_id"], _e["dest_full_id"])
+            if _pair not in seen_pairs:
+                seen_pairs.add(_pair)
+                deduped.append(_e)
+            else:
+                log.debug("  Duplicate edge suppressed: %s → %s", _e["source_label"], _e["dlo_name"])
+        edges = deduped
+
+        # Save full DSO details for every skipped stream so they can be
+        # reviewed, manually linked to MC assets, or used to diagnose mismatches.
+        if skipped:
+            try:
+                skip_path = _save_skipped_streams(run_id, skipped)
+                log.info(
+                    "  %d skipped stream(s) with full DSO details saved to: %s",
+                    len(skipped), skip_path,
+                )
+            except OSError as exc:
+                log.warning(
+                    "  Could not write skipped-streams file (%s). "
+                    "Run with LOG_LEVEL=DEBUG to see raw stream data in the log.",
+                    exc,
+                )
+
+    except (RuntimeError, requests.exceptions.RequestException) as exc:
+        log.error("Fatal error during data collection: %s", exc)
+        sys.exit(1)
+    except Exception as exc:
+        log.exception("Unexpected error during data collection: %s", exc)
+        sys.exit(2)
+
+    log.info("Resolved edges (%d total):", len(edges))
+    for e in edges:
+        log.info("  [%s] %s → %s", e["connector_type"], e["source_label"], e["dlo_name"])
+
+    if not edges:
+        log.warning(
+            "0 edges ready to push. "
+            "If source or DLO tables are missing from the MC catalog, trigger a metadata sync "
+            "(Settings → Integrations → your connection) then re-run. "
+            "The push is idempotent — re-running is safe once tables appear."
+        )
+        sys.exit(0)
+
+    if args.dry_run:
+        _by_type: dict = {}
+        for _e in edges:
+            _by_type[_e["connector_type"]] = _by_type.get(_e["connector_type"], 0) + 1
+        _breakdown = ", ".join(f"{ct}={n}" for ct, n in sorted(_by_type.items()))
+        log.info(
+            "[dry-run] Would push %d edge(s) (%s); %d stream(s) skipped. "
+            "Elapsed: %.1fs. Run without --dry-run to commit.",
+            len(edges), _breakdown or "none", len(skipped), time.monotonic() - t_start,
+        )
+        sys.exit(0)
+
+    try:
+        pushed_count = mc_svc.push_edges(edges, run_id, _shutdown_requested)
+    except KeyboardInterrupt:
+        log.warning("Interrupted during push — partial results may have been written to Monte Carlo.")
+        sys.exit(1)
+    except Exception as exc:
+        log.exception("Unexpected error during push: %s", exc)
+        sys.exit(2)
+
+    elapsed = time.monotonic() - t_start
+
+    # Exit 1 if every edge failed — treat as a systemic error, not partial success
+    if pushed_count == 0 and len(edges) > 0:
+        log.error(
+            "=== Run failed | run_id=%s | %.1fs | streams=%d | edges_resolved=%d | "
+            "edges_pushed=0 | skipped=%d ===",
+            run_id, elapsed, len(streams), len(edges), len(skipped),
+        )
+        sys.exit(1)
+
+    log.info(
+        "=== Run complete | run_id=%s | %.1fs | streams=%d | edges_resolved=%d | "
+        "edges_pushed=%d | skipped=%d ===",
+        run_id, elapsed, len(streams), len(edges), pushed_count, len(skipped),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_external_lineage.py
@@ -1403,7 +1403,10 @@ def _run_discover(streams: list, run_id: str, instance_url: str) -> None:
 # ── Step 5: Push via Ingest API (cross-warehouse) ─────────────────────────────
 
 def _is_ingest_retryable(exc: BaseException) -> bool:
+    # pycarlo wraps HTTPError into IngestionError (no .response); check __cause__ too
     resp = getattr(exc, "response", None)
+    if resp is None and exc.__cause__ is not None:
+        resp = getattr(exc.__cause__, "response", None)
     if resp is not None and 400 <= resp.status_code < 500:
         return False
     return True

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -370,6 +370,7 @@ class SalesforceDataCloudService:
             )
         resp.raise_for_status()
         self._token = data["access_token"]
+        self.client_secret = ""  # drop reference after use
         log.info("  Authenticated (%.1fs)", time.monotonic() - t0)
 
     @_retrying
@@ -533,7 +534,12 @@ class SalesforceDataCloudService:
         # Fast list to discover all record names (~0.5s)
         names = self._list_ostm_names()
         if not names:
-            log.warning("  listMetadata returned 0 ObjectSourceTargetMap records")
+            log.error(
+                "  listMetadata returned 0 ObjectSourceTargetMap records. "
+                "This means either (a) the org has no DLO→DMO mappings yet, or "
+                "(b) the connected Salesforce user lacks Metadata API read access. "
+                "Verify permissions with sf_diagnostic.py before re-running."
+            )
             buf = io.BytesIO()
             with zipfile.ZipFile(buf, "w"):
                 pass
@@ -1335,12 +1341,12 @@ def main() -> None:
 
     log.info("DLO->DMO edges (%d total):", len(dlo_edges))
     for e in dlo_edges:
-        log.info("  [%s] %s -> %s", e["data_space"], e["source"], e["target"])
+        log.debug("  [%s] %s -> %s", e["data_space"], e["source"], e["target"])
 
     if not args.skip_cio:
         log.info("DMO->CIO edges (%d total):", len(cio_edges))
         for e in cio_edges:
-            log.info("  [%s] %s -> %s", e["data_space"], e["source"], e["target"])
+            log.debug("  [%s] %s -> %s", e["data_space"], e["source"], e["target"])
 
     if not dlo_edges and not cio_edges:
         log.warning(

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -51,7 +51,7 @@ from defusedxml.ElementTree import ParseError as _ETParseError
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 from xml.sax.saxutils import escape
 
 import requests
@@ -721,6 +721,15 @@ class SalesforceDataCloudService:
 
     def _validate_same_origin(self, url: str) -> str:
         """Return absolute URL, rejecting any nextPageUrl that crosses origin or uses non-HTTPS."""
+        # Salesforce sometimes returns nextPageUrl with null-valued params (e.g.
+        # definitionType=null) which it then rejects on the subsequent request.
+        _p = urlparse(url)
+        _clean_qs = urlencode(
+            {k: v for k, v in parse_qs(_p.query, keep_blank_values=True).items()
+             if v and v[0] not in ("null", "")},
+            doseq=True,
+        )
+        url = urlunparse(_p._replace(query=_clean_qs))
         parsed_base = urlparse(self.instance_url)
         parsed = urlparse(url)
         if not parsed.scheme:

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -731,8 +731,9 @@ class SalesforceDataCloudService:
         # definitionType=null) which it then rejects on the subsequent request.
         _p = urlparse(url)
         _clean_qs = urlencode(
-            {k: v for k, v in parse_qs(_p.query, keep_blank_values=True).items()
-             if v and v[0] not in ("null", "")},
+            {k: [x for x in v if x not in ("null", "")]
+             for k, v in parse_qs(_p.query, keep_blank_values=True).items()
+             if any(x not in ("null", "") for x in v)},
             doseq=True,
         )
         url = urlunparse(_p._replace(query=_clean_qs))

--- a/examples/push-ingestion/salesforce-data-cloud/requirements.txt
+++ b/examples/push-ingestion/salesforce-data-cloud/requirements.txt
@@ -1,5 +1,5 @@
-requests>=2.31.0
-python-dotenv>=1.0.0
+requests>=2.33.0
+python-dotenv>=1.2.2
 pycarlo>=0.12.251
 tenacity>=8.2.0
 defusedxml>=0.7.1

--- a/examples/push-ingestion/salesforce-data-cloud/requirements.txt
+++ b/examples/push-ingestion/salesforce-data-cloud/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.33.0
 python-dotenv>=1.2.2
-pycarlo>=0.12.251
+pycarlo>=0.12.478
 tenacity>=8.2.0
 defusedxml>=0.7.1

--- a/examples/push-ingestion/salesforce-data-cloud/run_all.py
+++ b/examples/push-ingestion/salesforce-data-cloud/run_all.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Data 360 Full Lineage Push
+
+One command to push complete end-to-end lineage for Salesforce Data 360:
+
+  Step A  push_external_lineage.py   Source (CRM / Snowflake) → DLO
+  Step B  push_lineage.py            DLO → DMO → CIO
+
+Each script can also be run independently when you only need one hop.
+
+Usage:
+  python3 run_all.py               # full end-to-end push
+  python3 run_all.py --dry-run     # preview every edge without committing
+  python3 run_all.py --discover    # scan Data Stream connector types (Step A only)
+
+Flags are forwarded to the individual scripts where they apply:
+  --dry-run   passed to both scripts
+  --discover  passed to push_external_lineage.py only; push_lineage.py is skipped
+"""
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+_STEP_A = ("Source → DLO  (push_external_lineage.py)", "push_external_lineage.py")
+_STEP_B = ("DLO → DMO → CIO  (push_lineage.py)", "push_lineage.py")
+
+
+def _run_step(label: str, script: str, extra_args: list) -> int:
+    separator = "─" * 64
+    print(f"\n{separator}", flush=True)
+    print(f"  {label}", flush=True)
+    print(f"{separator}", flush=True)
+    result = subprocess.run(
+        [sys.executable, str(HERE / script)] + extra_args,
+        check=False,
+    )
+    return result.returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Push complete Salesforce Data 360 lineage to Monte Carlo "
+            "(Source→DLO then DLO→DMO→CIO)"
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run all steps but skip the MC push",
+    )
+    parser.add_argument(
+        "--discover",
+        action="store_true",
+        help=(
+            "Scan Data Stream connector types and exit — "
+            "runs push_external_lineage.py --discover only, no MC catalog or push"
+        ),
+    )
+    args = parser.parse_args()
+
+    base_args = ["--dry-run"] if args.dry_run else []
+
+    # Step A: Source → DLO
+    step_a_args = base_args + (["--discover"] if args.discover else [])
+    rc = _run_step(*_STEP_A, step_a_args)
+    if rc != 0:
+        print(f"\n[run_all] Step A exited with code {rc} — stopping.", flush=True)
+        sys.exit(rc)
+
+    # Step B: DLO → DMO → CIO (skipped in --discover mode)
+    if not args.discover:
+        rc = _run_step(*_STEP_B, base_args)
+        if rc != 0:
+            print(f"\n[run_all] Step B exited with code {rc}.", flush=True)
+            sys.exit(rc)
+
+    print("\n[run_all] All lineage steps complete.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
+++ b/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
@@ -495,8 +495,9 @@ def check_calculated_insights(instance_url, token):
             # definitionType=null) which it then rejects on the subsequent request.
             _pn = urlparse(raw_next)
             _clean_qs = urlencode(
-                {k: v for k, v in parse_qs(_pn.query, keep_blank_values=True).items()
-                 if v and v[0] not in ("null", "")},
+                {k: [x for x in v if x not in ("null", "")]
+                 for k, v in parse_qs(_pn.query, keep_blank_values=True).items()
+                 if any(x not in ("null", "") for x in v)},
                 doseq=True,
             )
             raw_next = urlunparse(_pn._replace(query=_clean_qs))

--- a/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
+++ b/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
@@ -23,7 +23,7 @@ import sys
 import time
 import zipfile
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 from defusedxml.ElementTree import ParseError as _ETParseError
 from xml.sax.saxutils import escape
 
@@ -491,6 +491,15 @@ def check_calculated_insights(instance_url, token):
 
         raw_next = collection.get("nextPageUrl") or None
         if raw_next:
+            # Salesforce sometimes returns nextPageUrl with null-valued params (e.g.
+            # definitionType=null) which it then rejects on the subsequent request.
+            _pn = urlparse(raw_next)
+            _clean_qs = urlencode(
+                {k: v for k, v in parse_qs(_pn.query, keep_blank_values=True).items()
+                 if v and v[0] not in ("null", "")},
+                doseq=True,
+            )
+            raw_next = urlunparse(_pn._replace(query=_clean_qs))
             parsed_next = urlparse(raw_next)
             if not parsed_next.scheme:
                 if not raw_next.startswith("/"):

--- a/examples/push-ingestion/salesforce-data-cloud/test_push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/test_push_external_lineage.py
@@ -623,38 +623,40 @@ class TestPushEdges:
             "source_label": f"Snowflake:{src}",
         }
 
-    @patch("push_external_lineage._push_one_edge")
-    def test_all_succeed(self, mock_push):
-        mock_push.return_value = {"createOrUpdateLineageEdge": {"edge": {"source": {"mcon": "m1"}, "destination": {"mcon": "m2"}}}}
+    @patch("push_external_lineage._send_batch")
+    @patch("push_external_lineage.IngestionService")
+    def test_all_succeed(self, mock_svc_cls, mock_send):
+        mock_send.return_value = {"invocation_id": "inv123"}
         edges = [self._make_edge(), self._make_edge(src="src2:s.t2", dst="dst:default.DLO2__dll")]
         count = sut.push_edges(edges, "key_id", "key_secret", "run123")
         assert count == 2
 
-    @patch("push_external_lineage._push_one_edge")
-    def test_failure_counted(self, mock_push, tmp_path, monkeypatch):
+    @patch("push_external_lineage._send_batch")
+    @patch("push_external_lineage.IngestionService")
+    def test_failure_counted(self, mock_svc_cls, mock_send, tmp_path, monkeypatch):
         monkeypatch.setattr(sut, "__file__", str(tmp_path / "push_external_lineage.py"))
-        mock_push.side_effect = RuntimeError("network error")
+        mock_send.side_effect = RuntimeError("network error")
         edges = [self._make_edge()]
         count = sut.push_edges(edges, "key_id", "key_secret", "run123")
         assert count == 0
 
-    @patch("push_external_lineage._push_one_edge")
-    def test_sigterm_stops_cleanly(self, mock_push):
-        mock_push.return_value = {"createOrUpdateLineageEdge": {"edge": {"source": {"mcon": "m"}, "destination": {"mcon": "d"}}}}
+    @patch("push_external_lineage._send_batch")
+    @patch("push_external_lineage.IngestionService")
+    def test_sigterm_stops_cleanly(self, mock_svc_cls, mock_send):
+        mock_send.return_value = {"invocation_id": "inv1"}
         flag = threading.Event()
         edges = [self._make_edge()] * 5
 
-        original_push = sut._push_one_edge
-
         call_count = [0]
-        def stopping_push(*args, **kwargs):
+        def stopping_send(*args, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
                 flag.set()
-            return mock_push.return_value
+            return {"invocation_id": "inv"}
 
-        mock_push.side_effect = stopping_push
-        count = sut.push_edges(edges, "key_id", "key_secret", "run123", shutdown_flag=flag)
+        mock_send.side_effect = stopping_send
+        # batch_size=1 → one batch per edge; flag set after batch 2 → stops before batch 3
+        count = sut.push_edges(edges, "key_id", "key_secret", "run123", batch_size=1, shutdown_flag=flag)
         assert count < 5  # stopped early
 
 
@@ -673,29 +675,26 @@ class TestValidateUuid:
             sut._validate_uuid("TEST", "")
 
 
-# ── _is_push_retryable ────────────────────────────────────────────────────────
+# ── _is_ingest_retryable ──────────────────────────────────────────────────────
 
-class TestIsPushRetryable:
-    def test_mcgraphqlerror_not_retryable(self):
-        assert not sut._is_push_retryable(sut.MCGraphQLError("perm failure"))
-
+class TestIsIngestRetryable:
     def test_4xx_not_retryable(self):
         exc = RuntimeError("bad request")
         resp = MagicMock()
         resp.status_code = 400
         exc.response = resp
-        assert not sut._is_push_retryable(exc)
+        assert not sut._is_ingest_retryable(exc)
 
     def test_500_retryable(self):
         exc = RuntimeError("server error")
         resp = MagicMock()
         resp.status_code = 500
         exc.response = resp
-        assert sut._is_push_retryable(exc)
+        assert sut._is_ingest_retryable(exc)
 
     def test_network_error_retryable(self):
         import requests as req_lib
-        assert sut._is_push_retryable(req_lib.exceptions.ConnectionError("timeout"))
+        assert sut._is_ingest_retryable(req_lib.exceptions.ConnectionError("timeout"))
 
 
 # ── Integration: edge deduplication in main pipeline context ──────────────────

--- a/examples/push-ingestion/salesforce-data-cloud/test_push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/test_push_external_lineage.py
@@ -1,0 +1,737 @@
+"""
+Comprehensive tests for push_external_lineage.py.
+
+Run:  pytest test_push_external_lineage.py -v
+"""
+import json
+import os
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+# Make the module importable without a .env file present
+os.environ.setdefault("SF_ORG_URL", "https://test.my.salesforce.com")
+os.environ.setdefault("SF_CLIENT_ID", "fake_id")
+os.environ.setdefault("SF_CLIENT_SECRET", "fake_secret")
+os.environ.setdefault("MCD_ID", "fake_mcd_id")
+os.environ.setdefault("MCD_TOKEN", "fake_mcd_token")
+os.environ.setdefault("MCD_DC_WAREHOUSE_UUID", "00000000-0000-0000-0000-000000000001")
+
+import push_external_lineage as sut
+
+
+# ── _sanitize_for_log ─────────────────────────────────────────────────────────
+
+class TestSanitizeForLog:
+    def test_newlines_replaced(self):
+        assert "\n" not in sut._sanitize_for_log("line1\nline2")
+        assert "\r" not in sut._sanitize_for_log("line1\rline2")
+
+    def test_tab_replaced(self):
+        assert "\t" not in sut._sanitize_for_log("col1\tcol2")
+
+    def test_null_byte_removed(self):
+        assert "\x00" not in sut._sanitize_for_log("before\x00after")
+
+    def test_ansi_escape_removed(self):
+        assert "\x1b" not in sut._sanitize_for_log("\x1b[31mred\x1b[0m")
+        assert sut._sanitize_for_log("\x1b[31mred\x1b[0m") == "red"
+
+    def test_bidi_override_replaced(self):
+        result = sut._sanitize_for_log("safe\u202emalicious")
+        assert "\u202e" not in result
+        assert "safe malicious" == result
+
+    def test_unicode_line_separator_replaced(self):
+        result = sut._sanitize_for_log("line1\u2028line2")
+        assert "\u2028" not in result
+
+    def test_unicode_paragraph_separator_replaced(self):
+        result = sut._sanitize_for_log("para1\u2029para2")
+        assert "\u2029" not in result
+
+    def test_truncation(self):
+        long_str = "a" * 500
+        assert len(sut._sanitize_for_log(long_str)) == 300
+        assert len(sut._sanitize_for_log(long_str, max_len=100)) == 100
+
+    def test_clean_string_unchanged(self):
+        assert sut._sanitize_for_log("hello world") == "hello world"
+
+
+# ── _redact_params ────────────────────────────────────────────────────────────
+
+class TestRedactParams:
+    def test_redacts_password(self):
+        result = sut._redact_params({"password": "secret123"})
+        assert result["password"] == "<redacted>"
+
+    def test_redacts_token(self):
+        assert sut._redact_params({"token": "abc"})["token"] == "<redacted>"
+
+    def test_redacts_case_insensitive(self):
+        assert sut._redact_params({"PASSWORD": "x"})["PASSWORD"] == "<redacted>"
+        assert sut._redact_params({"Client_Secret": "x"})["Client_Secret"] == "<redacted>"
+
+    def test_redacts_hyphenated_key(self):
+        # key normalized via .replace("-", "_") before checking
+        assert sut._redact_params({"bearer-token": "x"})["bearer-token"] == "<redacted>"
+
+    def test_preserves_non_sensitive(self):
+        result = sut._redact_params({"bucket": "my-bucket", "region": "us-east-1"})
+        assert result["bucket"] == "my-bucket"
+        assert result["region"] == "us-east-1"
+
+    def test_empty_dict(self):
+        assert sut._redact_params({}) == {}
+
+    def test_redacts_all_sensitive_names(self):
+        sensitive = {
+            "password": "x", "secret": "x", "token": "x", "key": "x",
+            "apikey": "x", "client_secret": "x", "access_key": "x",
+            "secret_access_key": "x", "private_key": "x", "session_token": "x",
+            "passphrase": "x", "ssh_private_key": "x", "bearer_token": "x",
+            "oauth_token": "x",
+        }
+        result = sut._redact_params(sensitive)
+        for k in sensitive:
+            assert result[k] == "<redacted>", f"Expected {k!r} to be redacted"
+
+
+# ── _sanitize_stream_for_disk ─────────────────────────────────────────────────
+
+class TestSanitizeStreamForDisk:
+    def test_redacts_nested_connector_details(self):
+        stream = {
+            "name": "MyStream",
+            "connectorInfo": {
+                "connectorType": "SNOWFLAKE",
+                "connectorDetails": {"password": "secret", "warehouse": "WH"},
+            },
+        }
+        result = sut._sanitize_stream_for_disk(stream)
+        assert result["connectorInfo"]["connectorDetails"]["password"] == "<redacted>"
+        assert result["connectorInfo"]["connectorDetails"]["warehouse"] == "WH"
+
+    def test_redacts_top_level_connector_details(self):
+        stream = {
+            "name": "MyStream",
+            "connectorDetails": {"token": "abc123", "bucket": "my-bucket"},
+        }
+        result = sut._sanitize_stream_for_disk(stream)
+        assert result["connectorDetails"]["token"] == "<redacted>"
+        assert result["connectorDetails"]["bucket"] == "my-bucket"
+
+    def test_redacts_advanced_attributes(self):
+        stream = {
+            "advancedAttributes": {"password": "pw", "object": "Account"},
+        }
+        result = sut._sanitize_stream_for_disk(stream)
+        assert result["advancedAttributes"]["password"] == "<redacted>"
+        assert result["advancedAttributes"]["object"] == "Account"
+
+    def test_non_dict_connector_details_becomes_empty(self):
+        stream = {"connectorInfo": {"connectorDetails": ["list", "not", "dict"]}}
+        result = sut._sanitize_stream_for_disk(stream)
+        assert result["connectorInfo"]["connectorDetails"] == {}
+
+    def test_non_dict_advanced_attributes_becomes_empty(self):
+        stream = {"advancedAttributes": "not a dict"}
+        result = sut._sanitize_stream_for_disk(stream)
+        assert result["advancedAttributes"] == {}
+
+    def test_none_connector_info_handled(self):
+        stream = {"connectorInfo": None, "name": "test"}
+        result = sut._sanitize_stream_for_disk(stream)
+        assert result["connectorInfo"] == {}
+
+    def test_original_stream_not_mutated(self):
+        stream = {"connectorInfo": {"connectorDetails": {"password": "pw"}}}
+        sut._sanitize_stream_for_disk(stream)
+        assert stream["connectorInfo"]["connectorDetails"]["password"] == "pw"
+
+
+# ── _parse_warehouse_map ──────────────────────────────────────────────────────
+
+class TestParseWarehouseMap:
+    def test_single_entry(self):
+        result = sut._parse_warehouse_map("abc123=uuid-val")
+        assert result == {"abc123": "uuid-val"}
+
+    def test_multiple_entries(self):
+        result = sut._parse_warehouse_map("key1=uuid1,key2=uuid2")
+        assert result == {"key1": "uuid1", "key2": "uuid2"}
+
+    def test_keys_lowercased(self):
+        result = sut._parse_warehouse_map("ABC=uuid1")
+        assert "abc" in result
+        assert "ABC" not in result
+
+    def test_whitespace_stripped(self):
+        result = sut._parse_warehouse_map(" key1 = uuid1 , key2 = uuid2 ")
+        assert result["key1"] == "uuid1"
+        assert result["key2"] == "uuid2"
+
+    def test_malformed_entry_skipped(self):
+        result = sut._parse_warehouse_map("good=uuid1,badentry,good2=uuid2")
+        assert "good" in result
+        assert "good2" in result
+        assert len(result) == 2
+
+    def test_empty_key_skipped(self):
+        result = sut._parse_warehouse_map("=uuid1,good=uuid2")
+        assert "" not in result
+        assert "good" in result
+
+    def test_empty_uuid_skipped(self):
+        result = sut._parse_warehouse_map("key1=,good=uuid2")
+        assert "key1" not in result
+        assert "good" in result
+
+    def test_empty_string_returns_empty(self):
+        assert sut._parse_warehouse_map("") == {}
+
+    def test_truncation_at_comma_boundary(self):
+        # Build a string slightly over 8192 bytes that ends mid-entry after truncation
+        entry = "k" * 100 + "=" + "u" * 100
+        # First good entry, then a padding entry, then a partial entry
+        raw = "good=uuid1," + ",".join([entry] * 40)
+        result = sut._parse_warehouse_map(raw)
+        # "good=uuid1" must survive
+        assert "good" in result
+        # No partial/malformed key should appear
+        for k in result:
+            assert "=" not in k
+
+
+# ── _extract_sf_account_identifier ───────────────────────────────────────────
+
+class TestExtractSfAccountIdentifier:
+    def test_standard_url(self):
+        assert sut._extract_sf_account_identifier(
+            "https://HDB68299.us-west-2.snowflakecomputing.com"
+        ) == "hdb68299.us-west-2"
+
+    def test_no_region(self):
+        assert sut._extract_sf_account_identifier(
+            "https://xy12345.snowflakecomputing.com"
+        ) == "xy12345"
+
+    def test_lowercase_passthrough(self):
+        assert sut._extract_sf_account_identifier(
+            "https://abc.eu-west-1.snowflakecomputing.com"
+        ) == "abc.eu-west-1"
+
+    def test_url_with_trailing_slash(self):
+        result = sut._extract_sf_account_identifier(
+            "https://abc.us-east-1.snowflakecomputing.com/"
+        )
+        assert result == "abc.us-east-1"
+
+    def test_non_snowflake_url_returns_hostname(self):
+        result = sut._extract_sf_account_identifier("https://other.example.com")
+        assert result == "other.example.com"
+
+
+# ── _CatalogIndex / _lookup ───────────────────────────────────────────────────
+
+def _make_catalog(*full_table_ids: str) -> sut._CatalogIndex:
+    by_full: dict = {}
+    by_name: dict = {}
+    for fid in full_table_ids:
+        by_full[fid.lower()] = fid
+        if "." in fid:
+            name = fid.rsplit(".", 1)[1].lower()
+            if name not in by_name:
+                by_name[name] = fid
+            else:
+                existing = by_name[name]
+                if isinstance(existing, list):
+                    existing.append(fid)
+                else:
+                    by_name[name] = [existing, fid]
+    return sut._CatalogIndex(by_full=by_full, by_name=by_name, table_count=len(full_table_ids))
+
+
+class TestLookup:
+    def test_exact_full_match(self):
+        idx = _make_catalog("salesforce-data-cloud:default.Account_Home__dll")
+        result = sut._lookup(idx, "salesforce-data-cloud:default.Account_Home__dll", "DC")
+        assert result == "salesforce-data-cloud:default.Account_Home__dll"
+
+    def test_case_insensitive_full_match(self):
+        idx = _make_catalog("salesforce-data-cloud:default.Account_Home__dll")
+        result = sut._lookup(idx, "SALESFORCE-DATA-CLOUD:DEFAULT.ACCOUNT_HOME__DLL", "DC")
+        assert result == "salesforce-data-cloud:default.Account_Home__dll"
+
+    def test_name_only_match(self):
+        idx = _make_catalog("salesforce-data-cloud:default.Account_Home__dll")
+        result = sut._lookup(idx, "Account_Home__dll", "DC")
+        assert result == "salesforce-data-cloud:default.Account_Home__dll"
+
+    def test_miss_returns_none(self):
+        idx = _make_catalog("salesforce-data-cloud:default.Account_Home__dll")
+        assert sut._lookup(idx, "NonExistent__dll", "DC") is None
+
+    def test_ambiguous_name_returns_first_with_warning(self):
+        idx = _make_catalog(
+            "salesforce-data-cloud:default.Orders__dll",
+            "salesforce-data-cloud:prod.Orders__dll",
+        )
+        result = sut._lookup(idx, "Orders__dll", "DC")
+        assert result is not None  # returns first, not None
+
+
+# ── resolve_edges ─────────────────────────────────────────────────────────────
+
+def _make_stream(name: str, connector_type: str, dlo_name: str,
+                 source_object: str = "", **kwargs) -> dict:
+    stream: dict = {
+        "name": name,
+        "connectorInfo": {
+            "connectorType": connector_type,
+            "connectorDetails": {"sourceObject": source_object},
+        },
+        "dataLakeObjectInfo": {"name": dlo_name},
+    }
+    if "advanced" in kwargs:
+        stream["advancedAttributes"] = kwargs["advanced"]
+    return stream
+
+
+def _make_dc_idx(*dlo_names: str) -> sut._CatalogIndex:
+    return _make_catalog(*[f"salesforce-data-cloud:default.{n}" for n in dlo_names])
+
+
+def _make_crm_idx(*obj_names: str) -> sut._CatalogIndex:
+    return _make_catalog(*[f"crm:org.{n}" for n in obj_names])
+
+
+def _make_sf_idx(*table_ids: str) -> sut._CatalogIndex:
+    return _make_catalog(*table_ids)
+
+
+DC_UUID = "00000000-0000-0000-0000-000000000001"
+CRM_UUID = "00000000-0000-0000-0000-000000000002"
+SF_UUID = "00000000-0000-0000-0000-000000000003"
+
+
+class TestResolveEdges:
+    def _call(self, streams, dc_idx, crm_idx=None, sf_idx=None,
+              connection_details=None, sf_catalogs=None, crm_catalogs=None):
+        return sut.resolve_edges(
+            streams=streams,
+            dc_idx=dc_idx,
+            crm_idx=crm_idx,
+            sf_idx=sf_idx,
+            dc_warehouse_uuid=DC_UUID,
+            crm_warehouse_uuid=CRM_UUID if crm_idx else None,
+            snowflake_warehouse_uuid=SF_UUID if sf_idx else None,
+            connection_details=connection_details or {},
+            sf_catalogs=sf_catalogs or {},
+            crm_catalogs=crm_catalogs or {},
+        )
+
+    def test_crm_stream_resolved(self):
+        streams = [_make_stream("S1", "SalesforceDotCom", "Account__dll", "Account")]
+        dc_idx = _make_dc_idx("Account__dll")
+        crm_idx = _make_crm_idx("Account")
+        edges, skipped = self._call(streams, dc_idx, crm_idx=crm_idx)
+        assert len(edges) == 1
+        assert edges[0]["connector_type"] == "SalesforceDotCom"
+        assert edges[0]["source_warehouse"] == CRM_UUID
+        assert edges[0]["dest_warehouse"] == DC_UUID
+        assert len(skipped) == 0
+
+    def test_crm_stream_skipped_no_warehouse(self):
+        streams = [_make_stream("S1", "SalesforceDotCom", "Account__dll", "Account")]
+        dc_idx = _make_dc_idx("Account__dll")
+        edges, skipped = self._call(streams, dc_idx)  # no crm_idx
+        assert len(edges) == 0
+        assert skipped[0]["reason"] == "crm_warehouse_uuid_not_configured"
+
+    def test_crm_stream_skipped_source_not_in_mc(self):
+        streams = [_make_stream("S1", "SalesforceDotCom", "Account__dll", "Account")]
+        dc_idx = _make_dc_idx("Account__dll")
+        crm_idx = _make_crm_idx()  # empty catalog
+        edges, skipped = self._call(streams, dc_idx, crm_idx=crm_idx)
+        assert len(edges) == 0
+        assert skipped[0]["reason"] == "source_not_in_mc_catalog"
+
+    def test_dlo_not_in_mc_catalog_skipped(self):
+        streams = [_make_stream("S1", "SalesforceDotCom", "Missing__dll", "Account")]
+        dc_idx = _make_dc_idx()  # no DLOs in catalog
+        crm_idx = _make_crm_idx("Account")
+        edges, skipped = self._call(streams, dc_idx, crm_idx=crm_idx)
+        assert len(edges) == 0
+        assert skipped[0]["reason"] == "dlo_not_in_mc_catalog"
+
+    def test_missing_dlo_name_skipped(self):
+        stream = {"name": "S1", "connectorInfo": {"connectorType": "SalesforceDotCom"}, "dataLakeObjectInfo": {}}
+        edges, skipped = self._call([stream], _make_dc_idx())
+        assert skipped[0]["reason"] == "missing_dlo_name"
+
+    def test_unsupported_connector_skipped(self):
+        stream = _make_stream("S1", "OracleDB", "Foo__dll", "Table")
+        dc_idx = _make_dc_idx("Foo__dll")
+        edges, skipped = self._call([stream], dc_idx)
+        assert len(edges) == 0
+        assert skipped[0]["reason"] == "unsupported_connector"
+
+    def test_awss3_connector_unsupported(self):
+        """AwsS3 streams are explicitly unsupported — S3 requires custom node creation."""
+        stream = {
+            "name": "S1",
+            "connectorInfo": {"connectorType": "AwsS3"},
+            "dataLakeObjectInfo": {"name": "Accounts__dll"},
+            "advancedAttributes": {"fileName": "accounts.csv"},
+        }
+        dc_idx = _make_dc_idx("Accounts__dll")
+        edges, skipped = self._call([stream], dc_idx)
+        assert len(edges) == 0
+        assert skipped[0]["reason"] == "unsupported_connector"
+
+    def test_snowflake_stream_resolved(self):
+        stream = _make_stream("S1", "SNOWFLAKE", "Orders__dll", advanced={
+            "database": "MYDB", "schema": "PUBLIC", "object": "ORDERS"
+        })
+        dc_idx = _make_dc_idx("Orders__dll")
+        sf_idx = _make_sf_idx("MYDB:PUBLIC.ORDERS")
+        edges, skipped = self._call([stream], dc_idx, sf_idx=sf_idx)
+        assert len(edges) == 1
+        assert edges[0]["connector_type"] == "SNOWFLAKE"
+        assert edges[0]["source_warehouse"] == SF_UUID
+
+    def test_snowflake_missing_object_skipped(self):
+        stream = _make_stream("S1", "SNOWFLAKE", "Orders__dll", advanced={
+            "database": "MYDB", "schema": "PUBLIC"  # no "object"
+        })
+        dc_idx = _make_dc_idx("Orders__dll")
+        sf_idx = _make_sf_idx("MYDB:PUBLIC.ORDERS")
+        edges, skipped = self._call([stream], dc_idx, sf_idx=sf_idx)
+        assert skipped[0]["reason"] == "missing_snowflake_object"
+
+    def test_snowflake_no_warehouse_configured_skipped(self):
+        stream = _make_stream("S1", "SNOWFLAKE", "Orders__dll", advanced={
+            "database": "MYDB", "schema": "PUBLIC", "object": "ORDERS"
+        })
+        dc_idx = _make_dc_idx("Orders__dll")
+        edges, skipped = self._call([stream], dc_idx)  # no sf_idx
+        assert skipped[0]["reason"] == "snowflake_warehouse_not_configured"
+
+    def test_duplicate_edges_deduplicated(self):
+        """Two streams that produce the same source→DLO pair should yield one edge."""
+        s1 = _make_stream("S1", "SalesforceDotCom", "Account__dll", "Account")
+        s2 = _make_stream("S2", "SalesforceDotCom", "Account__dll", "Account")
+        dc_idx = _make_dc_idx("Account__dll")
+        crm_idx = _make_crm_idx("Account")
+        edges, _ = self._call([s1, s2], dc_idx, crm_idx=crm_idx)
+        assert len(edges) == 2  # resolve_edges returns both; deduplication happens in main()
+
+    def test_linked_crm_org_not_in_map_skipped(self):
+        """A CRM stream with a connector_id not in crm_catalogs should skip, not fall back."""
+        conn_details = {"S1": {"connector_id": "0XA000000000001"}}
+        stream = _make_stream("S1", "SalesforceDotCom", "Account__dll", "Account")
+        dc_idx = _make_dc_idx("Account__dll")
+        crm_idx = _make_crm_idx("Account")
+        # crm_catalogs is populated (has entries) but doesn't contain this connector_id
+        other_catalog = _make_crm_idx("Account")
+        crm_catalogs = {"0xa000000000002": (other_catalog, CRM_UUID)}
+        edges, skipped = self._call(
+            [stream], dc_idx,
+            crm_idx=crm_idx,
+            connection_details=conn_details,
+            crm_catalogs=crm_catalogs,
+        )
+        assert len(edges) == 0
+        assert skipped[0]["reason"] == "linked_crm_org_not_in_warehouse_map"
+
+    def test_crm_multi_org_routed_correctly(self):
+        """A CRM stream whose connector_id is in crm_catalogs routes to the correct catalog."""
+        conn_details = {"S1": {"connector_id": "0XA000000000001"}}
+        stream = _make_stream("S1", "SalesforceDotCom", "Account__dll", "Account")
+        dc_idx = _make_dc_idx("Account__dll")
+        specific_crm_idx = _make_crm_idx("Account")
+        crm_catalogs = {"0xa000000000001": (specific_crm_idx, "uuid-specific-crm")}
+        edges, skipped = self._call(
+            [stream], dc_idx,
+            connection_details=conn_details,
+            crm_catalogs=crm_catalogs,
+        )
+        assert len(edges) == 1
+        assert edges[0]["source_warehouse"] == "uuid-specific-crm"
+
+
+# ── _http ─────────────────────────────────────────────────────────────────────
+
+class TestHttp:
+    def _mock_response(self, status_code, body=None, headers=None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = headers or {}
+        resp.json.return_value = body or {}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    @patch("push_external_lineage.requests.request")
+    def test_default_allow_redirects_false(self, mock_req):
+        mock_req.return_value = self._mock_response(200)
+        sut._http("GET", "https://example.com")
+        _, kwargs = mock_req.call_args
+        assert kwargs.get("allow_redirects") is False
+
+    @patch("push_external_lineage.requests.request")
+    def test_explicit_allow_redirects_true_honored(self, mock_req):
+        mock_req.return_value = self._mock_response(200)
+        sut._http("GET", "https://example.com", allow_redirects=True)
+        _, kwargs = mock_req.call_args
+        assert kwargs.get("allow_redirects") is True
+
+    @patch("push_external_lineage.requests.request")
+    def test_default_timeout_set(self, mock_req):
+        mock_req.return_value = self._mock_response(200)
+        sut._http("GET", "https://example.com")
+        _, kwargs = mock_req.call_args
+        assert kwargs.get("timeout") == 30
+
+    @patch("push_external_lineage.requests.request")
+    def test_3xx_raises_when_redirects_false(self, mock_req):
+        mock_req.return_value = self._mock_response(
+            302, headers={"Location": "https://other.com/path"}
+        )
+        import requests as req_lib
+        with pytest.raises(req_lib.exceptions.TooManyRedirects):
+            sut._http("GET", "https://example.com", max_retries=0)
+
+    @patch("push_external_lineage.time.sleep")
+    @patch("push_external_lineage.requests.request")
+    def test_429_retries_with_retry_after(self, mock_req, mock_sleep):
+        ok = self._mock_response(200)
+        rate_limited = self._mock_response(429, headers={"Retry-After": "5"})
+        rate_limited.raise_for_status = MagicMock(side_effect=Exception("rate limit"))
+        mock_req.side_effect = [rate_limited, ok]
+        result = sut._http("GET", "https://example.com", max_retries=1)
+        assert result.status_code == 200
+        mock_sleep.assert_called_once_with(5.0)
+
+    @patch("push_external_lineage.time.sleep")
+    @patch("push_external_lineage.requests.request")
+    def test_5xx_retried(self, mock_req, mock_sleep):
+        ok = self._mock_response(200)
+        server_err = self._mock_response(500)
+        mock_req.side_effect = [server_err, ok]
+        result = sut._http("GET", "https://example.com", max_retries=1)
+        assert result.status_code == 200
+
+    @patch("push_external_lineage.requests.request")
+    def test_200_returned_directly(self, mock_req):
+        mock_req.return_value = self._mock_response(200, {"data": "ok"})
+        result = sut._http("GET", "https://example.com", max_retries=0)
+        assert result.status_code == 200
+
+
+# ── _gql ──────────────────────────────────────────────────────────────────────
+
+class TestGql:
+    def _make_http_response(self, body: dict, status: int = 200):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = body
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    @patch("push_external_lineage._http")
+    def test_returns_data_field(self, mock_http):
+        mock_http.return_value = self._make_http_response({"data": {"getTables": []}})
+        result = sut._gql("query {}", "id", "token")
+        assert result == {"getTables": []}
+
+    @patch("push_external_lineage._http")
+    def test_null_data_raises_mcgrapqlerror(self, mock_http):
+        mock_http.return_value = self._make_http_response({"data": None})
+        with pytest.raises(sut.MCGraphQLError, match="null/missing"):
+            sut._gql("query {}", "id", "token")
+
+    @patch("push_external_lineage._http")
+    def test_missing_data_raises_mcgrapqlerror(self, mock_http):
+        mock_http.return_value = self._make_http_response({"errors": [{"message": "not found"}]})
+        with pytest.raises(sut.MCGraphQLError, match="not found"):
+            sut._gql("query {}", "id", "token")
+
+    @patch("push_external_lineage._http")
+    def test_variables_none_excluded(self, mock_http):
+        mock_http.return_value = self._make_http_response({"data": {}})
+        sut._gql("query {}", "id", "token", variables=None)
+        payload = mock_http.call_args[1]["json"]
+        assert "variables" not in payload
+
+    @patch("push_external_lineage._http")
+    def test_variables_dict_included(self, mock_http):
+        mock_http.return_value = self._make_http_response({"data": {}})
+        sut._gql("query {}", "id", "token", variables={"key": "value"})
+        payload = mock_http.call_args[1]["json"]
+        assert payload["variables"] == {"key": "value"}
+
+    @patch("push_external_lineage._http")
+    def test_max_retries_zero_passed_to_http(self, mock_http):
+        mock_http.return_value = self._make_http_response({"data": {}})
+        sut._gql("query {}", "id", "token")
+        assert mock_http.call_args[1].get("max_retries") == 0
+
+
+# ── _save_failed_edges / _save_skipped_streams ────────────────────────────────
+
+class TestAtomicFileSave:
+    def test_failed_edges_written_correctly(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sut, "__file__", str(tmp_path / "push_external_lineage.py"))
+        edges = [{"connector_type": "SNOWFLAKE", "dlo_name": "Foo__dll"}]
+        path = sut._save_failed_edges("testrun", edges)
+        assert Path(path).exists()
+        data = json.loads(Path(path).read_text())
+        assert data[0]["connector_type"] == "SNOWFLAKE"
+
+    def test_failed_edges_permissions(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sut, "__file__", str(tmp_path / "push_external_lineage.py"))
+        path = sut._save_failed_edges("testrun", [{"x": 1}])
+        mode = oct(Path(path).stat().st_mode)[-3:]
+        assert mode == "600"
+
+    def test_skipped_streams_written_correctly(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sut, "__file__", str(tmp_path / "push_external_lineage.py"))
+        skipped = [{"reason": "dlo_not_in_mc_catalog", "raw_stream": {}}]
+        path = sut._save_skipped_streams("testrun", skipped)
+        data = json.loads(Path(path).read_text())
+        assert data["skipped_count"] == 1
+        assert data["run_id"] == "testrun"
+
+
+# ── push_edges ────────────────────────────────────────────────────────────────
+
+class TestPushEdges:
+    def _make_edge(self, src="src:schema.table", dst="dst:default.DLO__dll",
+                   src_wh=SF_UUID, dst_wh=DC_UUID, ct="SNOWFLAKE"):
+        return {
+            "source_full_id": src,
+            "source_warehouse": src_wh,
+            "dest_full_id": dst,
+            "dest_warehouse": dst_wh,
+            "connector_type": ct,
+            "dlo_name": "DLO__dll",
+            "source_label": f"Snowflake:{src}",
+        }
+
+    @patch("push_external_lineage._push_one_edge")
+    def test_all_succeed(self, mock_push):
+        mock_push.return_value = {"createOrUpdateLineageEdge": {"edge": {"source": {"mcon": "m1"}, "destination": {"mcon": "m2"}}}}
+        edges = [self._make_edge(), self._make_edge(src="src2:s.t2", dst="dst:default.DLO2__dll")]
+        count = sut.push_edges(edges, "key_id", "key_secret", "run123")
+        assert count == 2
+
+    @patch("push_external_lineage._push_one_edge")
+    def test_failure_counted(self, mock_push, tmp_path, monkeypatch):
+        monkeypatch.setattr(sut, "__file__", str(tmp_path / "push_external_lineage.py"))
+        mock_push.side_effect = RuntimeError("network error")
+        edges = [self._make_edge()]
+        count = sut.push_edges(edges, "key_id", "key_secret", "run123")
+        assert count == 0
+
+    @patch("push_external_lineage._push_one_edge")
+    def test_sigterm_stops_cleanly(self, mock_push):
+        mock_push.return_value = {"createOrUpdateLineageEdge": {"edge": {"source": {"mcon": "m"}, "destination": {"mcon": "d"}}}}
+        flag = threading.Event()
+        edges = [self._make_edge()] * 5
+
+        original_push = sut._push_one_edge
+
+        call_count = [0]
+        def stopping_push(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                flag.set()
+            return mock_push.return_value
+
+        mock_push.side_effect = stopping_push
+        count = sut.push_edges(edges, "key_id", "key_secret", "run123", shutdown_flag=flag)
+        assert count < 5  # stopped early
+
+
+# ── _validate_uuid ────────────────────────────────────────────────────────────
+
+class TestValidateUuid:
+    def test_valid_uuid_passes(self):
+        sut._validate_uuid("TEST", "00000000-0000-0000-0000-000000000001")
+
+    def test_invalid_uuid_exits(self):
+        with pytest.raises(SystemExit):
+            sut._validate_uuid("TEST", "not-a-uuid")
+
+    def test_empty_string_exits(self):
+        with pytest.raises(SystemExit):
+            sut._validate_uuid("TEST", "")
+
+
+# ── _is_push_retryable ────────────────────────────────────────────────────────
+
+class TestIsPushRetryable:
+    def test_mcgraphqlerror_not_retryable(self):
+        assert not sut._is_push_retryable(sut.MCGraphQLError("perm failure"))
+
+    def test_4xx_not_retryable(self):
+        exc = RuntimeError("bad request")
+        resp = MagicMock()
+        resp.status_code = 400
+        exc.response = resp
+        assert not sut._is_push_retryable(exc)
+
+    def test_500_retryable(self):
+        exc = RuntimeError("server error")
+        resp = MagicMock()
+        resp.status_code = 500
+        exc.response = resp
+        assert sut._is_push_retryable(exc)
+
+    def test_network_error_retryable(self):
+        import requests as req_lib
+        assert sut._is_push_retryable(req_lib.exceptions.ConnectionError("timeout"))
+
+
+# ── Integration: edge deduplication in main pipeline context ──────────────────
+
+class TestEdgeDeduplication:
+    """Verify deduplication logic that lives in main() after resolve_edges."""
+
+    def test_dedup_removes_identical_pairs(self):
+        edges = [
+            {"source_full_id": "src1", "dest_full_id": "dst1", "source_label": "L1", "dlo_name": "D1", "connector_type": "CRM"},
+            {"source_full_id": "src1", "dest_full_id": "dst1", "source_label": "L1", "dlo_name": "D1", "connector_type": "CRM"},
+            {"source_full_id": "src2", "dest_full_id": "dst2", "source_label": "L2", "dlo_name": "D2", "connector_type": "CRM"},
+        ]
+        seen: set = set()
+        deduped: list = []
+        for e in edges:
+            pair = (e["source_full_id"], e["dest_full_id"])
+            if pair not in seen:
+                seen.add(pair)
+                deduped.append(e)
+        assert len(deduped) == 2
+
+    def test_different_pairs_kept(self):
+        edges = [
+            {"source_full_id": "src1", "dest_full_id": "dst1", "source_label": "L", "dlo_name": "D", "connector_type": "CRM"},
+            {"source_full_id": "src2", "dest_full_id": "dst2", "source_label": "L", "dlo_name": "D", "connector_type": "SF"},
+        ]
+        seen: set = set()
+        deduped: list = []
+        for e in edges:
+            pair = (e["source_full_id"], e["dest_full_id"])
+            if pair not in seen:
+                seen.add(pair)
+                deduped.append(e)
+        assert len(deduped) == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/examples/push-ingestion/salesforce-data-cloud/test_push_external_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/test_push_external_lineage.py
@@ -675,6 +675,30 @@ class TestValidateUuid:
             sut._validate_uuid("TEST", "")
 
 
+# ── _parse_full_table_id ──────────────────────────────────────────────────────
+
+class TestParseFullTableId:
+    def test_standard_format(self):
+        assert sut._parse_full_table_id("db:schema.table") == ("db", "schema", "table")
+
+    def test_salesforce_data_cloud(self):
+        assert sut._parse_full_table_id("salesforce-data-cloud:default.Orders__dll") == (
+            "salesforce-data-cloud", "default", "Orders__dll"
+        )
+
+    def test_multiple_dots_takes_last(self):
+        assert sut._parse_full_table_id("db:schema.sub.table") == ("db", "schema.sub", "table")
+
+    def test_no_colon(self):
+        db, schema, name = sut._parse_full_table_id("schema.table")
+        assert name == "table"
+
+    def test_no_dot(self):
+        db, schema, name = sut._parse_full_table_id("db:tablename")
+        assert db == "db"
+        assert name == "tablename"
+
+
 # ── _is_ingest_retryable ──────────────────────────────────────────────────────
 
 class TestIsIngestRetryable:
@@ -683,6 +707,17 @@ class TestIsIngestRetryable:
         resp = MagicMock()
         resp.status_code = 400
         exc.response = resp
+        assert not sut._is_ingest_retryable(exc)
+
+    def test_4xx_ingestion_error_not_retryable(self):
+        """pycarlo wraps HTTPError → IngestionError with no .response; fix checks __cause__."""
+        from pycarlo.features.ingestion.exceptions import IngestionError
+        from requests.exceptions import HTTPError
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        cause = HTTPError("forbidden", response=mock_resp)
+        exc = IngestionError("Lineage ingestion request failed")
+        exc.__cause__ = cause
         assert not sut._is_ingest_retryable(exc)
 
     def test_500_retryable(self):


### PR DESCRIPTION
## Summary

- Adds `push_external_lineage.py` — pushes Source (CRM / Snowflake) → DLO lineage edges using `createOrUpdateLineageEdge` GraphQL mutation
- Adds `run_all.py` wrapper — single command runs both hops: `Source→DLO` then `DLO→DMO→CIO`
- Updates `.env.example` to cover both scripts from a single config file
- Updates `requirements.txt` and `.gitignore` for the combined directory
- S3 / AwsS3 connector type explicitly unsupported (skip with warning) — cross-warehouse edge push requires existing catalog objects, not custom node creation

## How to use

```bash
# Full end-to-end push
python3 run_all.py

# Preview only (no MC push)
python3 run_all.py --dry-run

# Scan Data Stream connector types
python3 run_all.py --discover

# Run hops independently
python3 push_external_lineage.py   # Source→DLO only
python3 push_lineage.py            # DLO→DMO→CIO only
```

## Test plan

- [x] 83/83 unit tests pass (`test_push_external_lineage.py`)
- [x] Live-tested against a real Salesforce Data Cloud org: CRM edges pushed, Snowflake "node not found" edge saved to failed JSON (table not in MC catalog — expected)
- [x] `--dry-run` and `--discover` flags forwarded correctly by `run_all.py`
- [x] `MCD_RESOURCE_UUID` alias works for both scripts from a single `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)