### PR TITLE
fix(salesforce-data-cloud): fix CIO pagination 400 and add configurable batch size

### DIFF
--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -31,6 +31,7 @@ Optional env vars:
   METADATA_BATCH_SIZE    — ObjectSourceTargetMap records per retrieve batch (default: 10)
   METADATA_MAX_POLLS     — max SOAP polling attempts per batch (default: 120)
   METADATA_POLL_INTERVAL — seconds between SOAP polls (default: 5)
+  CIO_BATCH_SIZE         — CIOs per page from the calculated-insights API (default: 50)
   SF_DEFAULT_DATA_SPACE  — fallback data space name (default: default)
 """
 import argparse
@@ -115,6 +116,7 @@ INGEST_BATCH_SIZE      = _parse_positive_int("INGEST_BATCH_SIZE", 500)
 METADATA_BATCH_SIZE    = _parse_positive_int("METADATA_BATCH_SIZE", 10)
 METADATA_MAX_POLLS     = _parse_positive_int("METADATA_MAX_POLLS", 120)
 METADATA_POLL_INTERVAL = _parse_positive_float("METADATA_POLL_INTERVAL", 5.0)
+CIO_BATCH_SIZE         = _parse_positive_int("CIO_BATCH_SIZE", 50)
 
 ZIP_MAX_FILES  = 10_000
 ZIP_MAX_BYTES  = 500 * 1024 * 1024  # 500 MB
@@ -757,13 +759,15 @@ class SalesforceDataCloudService:
         """Return absolute URL, rejecting any nextPageUrl that crosses origin or uses non-HTTPS."""
         # Salesforce sometimes returns nextPageUrl with null-valued params (e.g.
         # definitionType=null) which it then rejects on the subsequent request.
+        # It also occasionally includes both `offset` and `pageToken` in nextPageUrl;
+        # sending both causes a 400 because pageToken already encodes the offset.
         _p = urlparse(url)
-        _clean_qs = urlencode(
-            {k: [x for x in v if x not in ("null", "")]
-             for k, v in parse_qs(_p.query, keep_blank_values=True).items()
-             if any(x not in ("null", "") for x in v)},
-            doseq=True,
-        )
+        _qs = {k: [x for x in v if x not in ("null", "")]
+               for k, v in parse_qs(_p.query, keep_blank_values=True).items()
+               if any(x not in ("null", "") for x in v)}
+        if "pageToken" in _qs and "offset" in _qs:
+            _qs.pop("pageToken", None)  # offset-based pagination is authoritative; pageToken conflicts
+        _clean_qs = urlencode(_qs, doseq=True)
         url = urlunparse(_p._replace(query=_clean_qs))
         parsed_base = urlparse(self.instance_url)
         parsed = urlparse(url)
@@ -815,6 +819,7 @@ class SalesforceDataCloudService:
         items = []
         url: Optional[str] = (
             f"{self.instance_url}/services/data/v{SF_API_VERSION}/ssot/calculated-insights"
+            f"?batchSize={CIO_BATCH_SIZE}"
         )
         page = 0
         while url:


### PR DESCRIPTION
## Summary

- **Bug fix**: Salesforce's `calculated-insights` API returns a `nextPageUrl` containing both `offset` and `pageToken` params, which conflict — sending both causes a `400 Bad Request` on page 2+. Fix strips `pageToken` when `offset` is also present so offset-based pagination is used consistently.
- **New env var**: `CIO_BATCH_SIZE` (default: 50) controls the number of CIOs fetched per page, matching the pattern of `METADATA_BATCH_SIZE` and `INGEST_BATCH_SIZE`. Set to `1` to force page-by-page fetching for pagination testing.

## Test plan

- [x] Verified fix with `CIO_BATCH_SIZE=1` against a 3-CIO org — 3 separate pages fetched cleanly, no 400
- [x] Verified default (`CIO_BATCH_SIZE=50`) against same org — all 3 CIOs on page 1, no errors
- [x] Both `push_lineage.py --dry-run` and `sf_diagnostic.py` pass end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)