### PR TITLE
Data Cloud lineage: migrate DLO→DMO from SOAP Metadata API to read-only REST

### DIFF
--- a/examples/push-ingestion/salesforce-data-cloud/.env.example
+++ b/examples/push-ingestion/salesforce-data-cloud/.env.example
@@ -118,17 +118,9 @@ MCD_RESOURCE_UUID=
 # Reduce if you hit request size limits.
 # INGEST_BATCH_SIZE=500
 
-# Maximum number of SOAP polling attempts when retrieving Salesforce metadata.
-# Default: 120. Each poll waits METADATA_POLL_INTERVAL seconds, so the default
-# timeout is 120 × 5 = 600 seconds (10 minutes). Increase for very large orgs.
-# METADATA_MAX_POLLS=120
-
-# Seconds between SOAP polls. Default: 5.
-# METADATA_POLL_INTERVAL=5
-
-# Number of ObjectSourceTargetMap records per Salesforce metadata retrieve batch. Default: 10.
-# Reduce if the Metadata API returns timeout or "too large" errors on Step 3.
-# METADATA_BATCH_SIZE=10
+# Parallel per-DMO mapping fetches when retrieving DLO→DMO edges from the read-only
+# Data Cloud REST API (/ssot/data-model-object-mappings). Default: 10.
+# MAPPING_MAX_WORKERS=10
 
 # Data space fallback — used when a DLO record's data space cannot be resolved.
 # Default: "default". Set this if your org uses a different primary data space name.

--- a/examples/push-ingestion/salesforce-data-cloud/README.md
+++ b/examples/push-ingestion/salesforce-data-cloud/README.md
@@ -23,15 +23,16 @@ The script runs an eight-step pipeline:
    app credentials. A single token covers all data spaces (no per-dataspace credentials needed).
 2. **Fetch Data Spaces** — enumerates your Data 360 data spaces so lineage is attributed
    to the correct schema partition.
-3. **Retrieve ObjectSourceTargetMap metadata** — calls the Salesforce SOAP Metadata API
-   to get every DLO→DMO mapping defined in your org.
-4. **Parse DLO→DMO edges** — extracts source/target pairs and preliminary data space from
-   the XML metadata.
-4b. **Validate catalog coverage** — bulk-fetches all tables for the warehouse from Monte
-    Carlo's catalog in one paginated query (scoped to your Data Cloud warehouse UUID to
-    prevent cross-org contamination), then validates each DLO and DMO against that result
-    locally. Edges for uncatalogued tables are skipped and logged, so you can see exactly
-    what's missing and re-run once the connector syncs.
+3. **Fetch the Monte Carlo catalog** — bulk-fetches all tables for the warehouse in one
+   paginated query (scoped to your Data Cloud warehouse UUID to prevent cross-org
+   contamination) and enumerates the catalogued DMOs to query.
+4. **Retrieve DLO→DMO mappings** — one **read-only** GET per catalogued DMO against the
+   Data Cloud REST API (`/ssot/data-model-object-mappings`). No SOAP Metadata API and
+   **no "Modify Metadata" permission** — the mapping records carry the same source/target
+   developer names.
+4b. **Validate catalog coverage** — validates each DLO and DMO against the catalog from
+    step 3 locally. Edges for uncatalogued tables are skipped and logged, so you can see
+    exactly what's missing and re-run once the connector syncs.
 5. **Fetch Calculated Insight Objects** — calls the Data Cloud REST API
    (`/ssot/calculated-insights`) to retrieve all CIOs and their SQL expressions.
 6. **Parse DMO→CIO edges** — scans each CIO's SQL expression for `__dlm` and `__cio`
@@ -128,8 +129,10 @@ Find it in the Monte Carlo UI: **Settings → Integrations → your Data Cloud c
 The script uses the **client credentials** OAuth flow. Your connected app must:
 
 - Have **"Enable Client Credentials Flow"** checked under OAuth settings
-- Have API access and permission to retrieve `ObjectSourceTargetMap` metadata
-- Be assigned to a run-as user with Metadata API access
+- Have the `api` OAuth scope, with a run-as user assigned a Data Cloud permission set
+  (Data Cloud Admin or Data Cloud User) so it can read the Data Cloud REST API
+- **No "Modify Metadata" / Metadata API permission is required** — DLO→DMO lineage is
+  read entirely from the read-only Data Cloud REST API
 
 Set `SF_ORG_URL` to your org's **My Domain URL**
 (e.g. `https://mycompany.my.salesforce.com`), not `login.salesforce.com`.
@@ -145,9 +148,9 @@ Before running the full script, you can validate Salesforce connectivity indepen
 python3 sf_diagnostic.py
 ```
 
-This tests OAuth auth, the Dataspace SOQL query, the SOAP Metadata API retrieve, parses
-the resulting XML, and calls the Calculated Insights REST endpoint — printing timing,
-edge count, and data space information for all pipeline steps.
+This tests OAuth auth, the Dataspace SOQL query, the read-only DLO→DMO mapping REST
+endpoint, and the Calculated Insights REST endpoint — printing timing, edge count, and
+data space information for all pipeline steps.
 Useful for handing to a Salesforce admin to confirm API access before involving MC credentials.
 
 ---
@@ -173,10 +176,11 @@ Example output:
 [10:42:03] [INFO   ] [run=a1b2c3d4]   Authenticated (0.8s)
 [10:42:04] [INFO   ] [run=a1b2c3d4] Step 2: Fetching Salesforce data spaces
 [10:42:04] [INFO   ] [run=a1b2c3d4]   Found 1 data space(s): ['default']
-[10:42:04] [INFO   ] [run=a1b2c3d4] Step 3: Retrieving ObjectSourceTargetMap metadata
-[10:42:15] [INFO   ] [run=a1b2c3d4]   All 27 record(s) retrieved in 20.4s
-[10:42:15] [INFO   ] [run=a1b2c3d4] Step 4: Parsing DLO->DMO edges from metadata
-[10:42:15] [INFO   ] [run=a1b2c3d4]   20 DLO->DMO edge(s) extracted (0.0s)
+[10:42:04] [INFO   ] [run=a1b2c3d4] Step 3: Fetching Monte Carlo catalog for warehouse <uuid>
+[10:42:06] [INFO   ] [run=a1b2c3d4]   Fetched 71 table(s) from MC catalog (1.3s)
+[10:42:06] [INFO   ] [run=a1b2c3d4]   46 catalogued DMO(s) to query for DLO->DMO mappings
+[10:42:06] [INFO   ] [run=a1b2c3d4] Step 4: Retrieving DLO->DMO mappings via Data Cloud REST API (read-only; 46 catalogued DMO(s))
+[10:42:09] [INFO   ] [run=a1b2c3d4]   22 DLO->DMO edge(s) extracted from 16 mapped DMO(s) (3.6s)
 [10:42:15] [INFO   ] [run=a1b2c3d4] Step 4b: Validating DLO and DMO tables exist in Monte Carlo catalog
 [10:42:28] [INFO   ] [run=a1b2c3d4]   Catalog check complete: 40 matched, 0 not in catalog (1.1s)
 [10:42:28] [INFO   ] [run=a1b2c3d4]   20 edge(s) ready to push
@@ -263,9 +267,7 @@ LOG_FORMAT=json python3 push_lineage.py 2>> /var/log/data360-lineage.jsonl
 | `LOG_LEVEL` | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `LOG_FORMAT` | plain | Set to `json` for structured log output |
 | `INGEST_BATCH_SIZE` | `500` | Edges per Monte Carlo push batch |
-| `METADATA_BATCH_SIZE` | `10` | ObjectSourceTargetMap records per retrieve batch (smaller = faster per-batch, more API calls) |
-| `METADATA_MAX_POLLS` | `120` | Max SOAP polling attempts per retrieve batch |
-| `METADATA_POLL_INTERVAL` | `5` | Seconds between SOAP polls |
+| `MAPPING_MAX_WORKERS` | `10` | Parallel per-DMO mapping fetches from the Data Cloud REST API |
 | `SF_DEFAULT_DATA_SPACE` | `default` | Fallback data space when XML has no `<dataSpace>` and the org has multiple data spaces |
 
 ---

--- a/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
+++ b/examples/push-ingestion/salesforce-data-cloud/TROUBLESHOOTING.md
@@ -16,7 +16,7 @@ Run with full debug logging:
 LOG_LEVEL=DEBUG python3 push_lineage.py --dry-run
 ```
 
-This prints every SOAP poll attempt, every catalog and edge decision, and step-level
+This prints every catalog and edge decision, and step-level
 events — without writing anything to Monte Carlo. It is safe to run as many times as needed.
 
 ---
@@ -79,61 +79,31 @@ UI: **Settings → Integrations → your Data Cloud connection**.
 
 ---
 
-## Metadata Retrieval Errors
+## DLO->DMO Mapping Retrieval Errors
 
-### Script appears to hang after "Step 3: Retrieving ObjectSourceTargetMap metadata"
+### `0 DLO->DMO edge(s) extracted` (Step 4)
 
-This is normal. The script first calls `listMetadata` to enumerate all records (~0.5s),
-then retrieves them in batches of 10 (configurable via `METADATA_BATCH_SIZE`). Each batch
-is an asynchronous SOAP job that typically completes in 5–10 seconds. Progress is logged
-after every batch with a rolling ETA:
+The read-only REST endpoint (`/ssot/data-model-object-mappings`) returned no source
+mappings for any catalogued DMO. Common causes:
+- No DLO->DMO mappings have been defined yet in Data 360.
+- The Data Cloud connector hasn't catalogued any DMOs in Monte Carlo yet — Step 3 will
+  show `0 catalogued DMO(s)`. Trigger a metadata sync in Monte Carlo and re-run.
 
-```
-[10:42:04] [INFO] Found 27 ObjectSourceTargetMap record(s) — retrieving in 3 batch(es) of up to 10
-[10:42:11] [INFO] Batch 1/3 complete (10 record(s), 6.5s) — est. 13s remaining
-[10:42:17] [INFO] Batch 2/3 complete (10 record(s), 6.5s) — est. 6s remaining
-[10:42:23] [INFO] Batch 3/3 complete (7 record(s), 6.4s)
-```
+Run with `LOG_LEVEL=DEBUG` for per-DMO detail.
 
-If you see no progress messages at all, run with `LOG_LEVEL=DEBUG` to see each poll attempt.
+### `Mapping fetch failed for DMO '<name>'` warnings
 
-### `Batch retrieve did not complete within Xs`
+One or more per-DMO mapping GETs errored (timeout or 5xx) and were skipped, so their
+edges may be missing. The push is idempotent — re-run once the transient issue clears.
+A `404` from the endpoint is **not** an error: it means that DMO has no source mappings
+and is skipped silently (most installed standard DMOs are unmapped). If fetches are slow
+on a large org, lower `MAPPING_MAX_WORKERS` and re-run.
 
-A single batch timed out. The default per-batch timeout is 120 polls × 5 seconds = 10 minutes,
-which should be sufficient for any batch size. Options:
-1. Reduce `METADATA_BATCH_SIZE` (e.g. `METADATA_BATCH_SIZE=5`) so each batch is smaller
-2. Increase `METADATA_MAX_POLLS` if the org is under heavy load
-3. Try again — Salesforce metadata retrieval can be slow under org load
-4. Check Salesforce org status at status.salesforce.com
+### `HTTP 403` fetching data model objects or mappings
 
-### `Salesforce retrieve job failed [INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY]`
-
-The connected app's run-as user does not have permission to retrieve
-`ObjectSourceTargetMap` metadata. The user needs a profile or permission set that
-includes Metadata API access and Data Cloud administrative permissions.
-
-### `Salesforce SOAP fault [sf:INVALID_SESSION_ID]`
-
-The OAuth token expired during a long metadata poll. This is unusual with client
-credentials (tokens are typically valid for 2 hours) but can occur. Re-run the script
-to get a fresh token.
-
-### `ZIP contained no .objectSourceTargetMap files`
-
-The retrieve succeeded but no `ObjectSourceTargetMap` records exist in the org.
-Possible causes:
-- No DLO→DMO mappings have been defined yet in Data 360
-- The metadata type is not available in this Salesforce edition
-
-Run with `LOG_LEVEL=DEBUG` to see the full list of files returned in the ZIP. If the
-ZIP contains files ending in a different extension, contact Monte Carlo support.
-
-### `DLO->DMO edges (0 total)` after a successful retrieve
-
-The metadata was retrieved but none of the records contained DLO→DMO mappings
-(objects ending in `__dll` → `__dlm`). Confirm that your Data 360 org has DLO→DMO
-transformation mappings configured. If you see records in the XML but they are being
-skipped, run with `LOG_LEVEL=DEBUG` to see per-file parse details.
+The connected app's run-as user cannot read the Data Cloud REST API. Grant the `api`
+OAuth scope and assign a Data Cloud permission set (Data Cloud Admin or User). This is
+standard read access — **no "Modify Metadata" / Metadata API permission is required.**
 
 ---
 
@@ -147,7 +117,7 @@ When a table is missing, its lineage edge is skipped and this warning is logged.
 **Common causes:**
 - The Monte Carlo Data Cloud connector has not yet completed its first metadata scan
 - The table was created in Salesforce after the last connector sync
-- The table name in the `ObjectSourceTargetMap` does not match the catalogued name
+- The table name in the mapping record does not match the catalogued name
 
 **What to do:**
 1. In Monte Carlo, go to Settings → Integrations → your Data Cloud connection
@@ -177,8 +147,8 @@ Run with `LOG_LEVEL=DEBUG` to see the specific error.
 ### Step 5 returns HTTP 403 (CIO fetch fails)
 
 The connected app does not have permission to call the Data Cloud REST API
-(`/services/data/v62.0/ssot/calculated-insights`). This is a different permission from
-the Metadata API used in Step 3.
+(`/services/data/v62.0/ssot/calculated-insights`). This is the same Data Cloud REST
+API family used for DLO->DMO mappings in Steps 3-4.
 
 **What to do:**
 1. In Salesforce Setup → App Manager → your connected app → Edit
@@ -277,9 +247,8 @@ This usually means:
 ### Lineage appears in Monte Carlo but under the wrong schema / data space
 
 The data space assigned to an edge in Monte Carlo comes from (in priority order):
-1. The MC catalog's `dataset` field (authoritative — set during Step 4b validation)
-2. The `<dataSpace>` field in the `ObjectSourceTargetMap` XML
-3. The `SF_DEFAULT_DATA_SPACE` env var (default: `"default"`)
+1. The MC catalog's `dataset` field (authoritative — resolved during Step 4b validation)
+2. The `SF_DEFAULT_DATA_SPACE` env var (default: `"default"`), as a last-resort fallback
 
 If edges are landing under the wrong data space after validation, check that the
 tables are catalogued correctly in Monte Carlo (Settings → Integrations → your Data
@@ -291,15 +260,20 @@ edge.
 ## Required Salesforce Permissions
 
 The connected app's run-as user must have the following permissions. Missing any of
-these is the most common cause of `INSUFFICIENT_ACCESS` and `403` errors.
+these is the most common cause of `403` errors.
 
 ### DLO→DMO lineage (Steps 1–4)
 
-**Run-as user profile permissions:**
+**Run-as user profile permission:**
 - `API Enabled`
-- `Modify Metadata Through Metadata API Functions` *(or `Modify All Data`)*
 
-These are set in Salesforce Setup → Users → your run-as user → Profile → Edit.
+**Run-as user permission set:**
+- `Data Cloud Admin` **or** `Data Cloud User` — grants read access to the Data Cloud REST
+  API, including `/ssot/data-model-object-mappings`
+
+> **No "Modify Metadata" / Metadata API permission is required.** DLO→DMO lineage is read
+> entirely from the read-only Data Cloud REST API; the earlier SOAP Metadata API path
+> (which required "Modify Metadata Through Metadata API Functions") has been removed.
 
 ### DMO→CIO lineage (Steps 5–8)
 
@@ -314,11 +288,11 @@ Assign in Salesforce Setup → Users → your run-as user → Permission Set Ass
 - `Access and manage your data (api)`
 - `Perform requests on your behalf at any time (refresh_token, offline_access)`
 
-> The CIO endpoint (`/services/data/v62.0/ssot/calculated-insights`) is a Data Cloud
-> REST API that is separate from the Metadata API. Profile permissions alone do not
-> grant access to it — the `Data Cloud Admin` or `Data Cloud User` permission set is
-> required. If you only need DLO→DMO lineage, use `--skip-cio` to bypass Steps 5–8
-> entirely and the permission set is not needed.
+> All Data Cloud REST endpoints used here — `/ssot/data-model-object-mappings` (DLO→DMO)
+> and `/ssot/calculated-insights` (CIOs) — require the `Data Cloud Admin` or `Data Cloud
+> User` permission set; profile permissions alone do not grant access. `--skip-cio`
+> bypasses only Steps 5–8 (CIOs); the Data Cloud permission set is still needed for the
+> DLO→DMO lineage in Steps 3–4.
 
 ---
 

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -237,6 +237,19 @@ def _safe_snippet(text: str, max_len: int = 200) -> str:
     return cleaned[:max_len]
 
 
+def _asset_type(name: str) -> str:
+    """
+    Monte Carlo objectType for a Data Cloud object, by suffix.
+
+    The Data Cloud connector catalogs DLOs (__dll) as `table` and DMOs (__dlm) /
+    CIOs (__cio) as `view` (verified live against the catalog). LineageAssetRef.type
+    MUST match the catalogued objectType, or the edge lands on a phantom duplicate
+    node instead of the real one — a TABLE-typed push to a view-catalogued DMO
+    creates a disconnected 'table' node next to the real 'view' (confirmed live).
+    """
+    return "TABLE" if name.endswith("__dll") else "VIEW"
+
+
 # ── Salesforce service ────────────────────────────────────────────────────────
 class SalesforceDataCloudService:
     """Encapsulates Salesforce authentication and metadata retrieval."""
@@ -907,13 +920,13 @@ class SalesforceDataCloudLineageService:
         events = [
             LineageEvent(
                 destination=LineageAssetRef(
-                    type="TABLE",
+                    type=_asset_type(e["target"]),
                     database=DB,
                     schema=e["data_space"],
                     name=e["target"],
                 ),
                 sources=[LineageAssetRef(
-                    type="TABLE",
+                    type=_asset_type(e["source"]),
                     database=DB,
                     schema=e["data_space"],
                     name=e["source"],

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -5,10 +5,11 @@ Data 360 Lineage Push — DLO→DMO and DMO→CIO (Pandora Push Model)
 Pipeline:
   1. Authenticate with Salesforce via OAuth client credentials
   2. Fetch Salesforce data spaces (for data-space resolution fallback)
-  3. Retrieve ObjectSourceTargetMap metadata via SOAP Metadata API
-  4. Parse DLO->DMO edges; assign preliminary data space from XML field or fallback
-  4b. Validate tables exist in MC catalog; overwrite data space with authoritative
-      value from MC catalog dataset field
+  3. Fetch the Monte Carlo catalog and enumerate the catalogued DMOs
+  4. Retrieve DLO->DMO mappings via the Data Cloud REST API — one read-only GET per
+     catalogued DMO (no SOAP Metadata API, no 'Modify Metadata' permission required)
+  4b. Validate tables exist in MC catalog; MC catalog dataset field is authoritative
+      for data space
   5. Fetch Calculated Insight Objects (CIOs) via Data Cloud REST API
   6. Parse DMO->CIO edges by extracting table references from each CIO's SQL expression
   7. Push DLO->DMO lineage to Monte Carlo via pycarlo IngestionService
@@ -28,14 +29,11 @@ Optional env vars:
   LOG_LEVEL              — DEBUG/INFO/WARNING/ERROR (default: INFO)
   LOG_FORMAT             — json for structured output (default: plain)
   INGEST_BATCH_SIZE      — edges per push batch (default: 500)
-  METADATA_BATCH_SIZE    — ObjectSourceTargetMap records per retrieve batch (default: 10)
-  METADATA_MAX_POLLS     — max SOAP polling attempts per batch (default: 120)
-  METADATA_POLL_INTERVAL — seconds between SOAP polls (default: 5)
+  MAPPING_MAX_WORKERS    — parallel per-DMO mapping fetches (default: 10)
   SF_DEFAULT_DATA_SPACE  — fallback data space name (default: default)
 """
 import argparse
-import base64
-import io
+import concurrent.futures
 import ipaddress
 import json
 import logging
@@ -46,13 +44,10 @@ import socket
 import sys
 import time
 import uuid
-import zipfile
-from defusedxml.ElementTree import ParseError as _ETParseError
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-from xml.sax.saxutils import escape
 
 import requests
 from dotenv import load_dotenv
@@ -62,13 +57,6 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
-
-try:
-    import defusedxml.ElementTree as SafeET
-except ImportError as err:
-    sys.exit(
-        f"ERROR: defusedxml is not installed. Run: pip install defusedxml>=0.7.1\n  ({err})"
-    )
 
 try:
     from pycarlo.core import Client, Session
@@ -100,34 +88,13 @@ def _parse_positive_int(name: str, default: int) -> int:
         sys.exit(f"Invalid {name}={raw!r}: {exc}")
 
 
-def _parse_positive_float(name: str, default: float) -> float:
-    raw = os.environ.get(name, str(default))
-    try:
-        val = float(raw)
-        if val <= 0:
-            raise ValueError("must be > 0")
-        return val
-    except ValueError as exc:
-        sys.exit(f"Invalid {name}={raw!r}: {exc}")
+INGEST_BATCH_SIZE   = _parse_positive_int("INGEST_BATCH_SIZE", 500)
+MAPPING_MAX_WORKERS = _parse_positive_int("MAPPING_MAX_WORKERS", 10)
 
-
-INGEST_BATCH_SIZE      = _parse_positive_int("INGEST_BATCH_SIZE", 500)
-METADATA_BATCH_SIZE    = _parse_positive_int("METADATA_BATCH_SIZE", 10)
-METADATA_MAX_POLLS     = _parse_positive_int("METADATA_MAX_POLLS", 120)
-METADATA_POLL_INTERVAL = _parse_positive_float("METADATA_POLL_INTERVAL", 5.0)
-
-ZIP_MAX_FILES  = 10_000
-ZIP_MAX_BYTES  = 500 * 1024 * 1024  # 500 MB
 # Safety ceiling on paginated API calls to prevent infinite loops if the API
 # returns a non-null next-page cursor indefinitely (server bug or misconfiguration).
 MAX_CIO_PAGES     = 1_000
 MAX_CATALOG_PAGES = 5_000
-
-OSTM_NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
-SOAP_NS = {
-    "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
-    "met":     "http://soap.sforce.com/2006/04/metadata",
-}
 
 # Matches any Data Cloud object name (DMO or CIO) anywhere in SQL text.
 # Scanning the full expression — rather than only FROM/JOIN clauses — means
@@ -135,62 +102,6 @@ SOAP_NS = {
 # The suffixes __dlm (DMO) and __cio (CIO) are unique to table objects;
 # fields use __c, so false positives are not a concern.
 _DATA_OBJECT_RE = re.compile(r"\b([A-Za-z0-9_]+(?:__dlm|__cio))\b", re.IGNORECASE)
-
-# ── SOAP envelope templates ───────────────────────────────────────────────────
-_LIST_METADATA_ENVELOPE = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:met="http://soap.sforce.com/2006/04/metadata">
-  <soapenv:Header>
-    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
-  </soapenv:Header>
-  <soapenv:Body>
-    <met:listMetadata>
-      <met:queries><met:type>ObjectSourceTargetMap</met:type></met:queries>
-      <met:asOfVersion>{api_version}</met:asOfVersion>
-    </met:listMetadata>
-  </soapenv:Body>
-</soapenv:Envelope>"""
-
-_RETRIEVE_BATCH_ENVELOPE = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:met="http://soap.sforce.com/2006/04/metadata">
-  <soapenv:Header>
-    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
-  </soapenv:Header>
-  <soapenv:Body>
-    <met:retrieve>
-      <met:retrieveRequest>
-        <met:apiVersion>{api_version}</met:apiVersion>
-        <met:unpackaged>
-          <met:types>
-            {members}
-            <met:name>ObjectSourceTargetMap</met:name>
-          </met:types>
-        </met:unpackaged>
-      </met:retrieveRequest>
-    </met:retrieve>
-  </soapenv:Body>
-</soapenv:Envelope>"""
-
-_STATUS_ENVELOPE = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:met="http://soap.sforce.com/2006/04/metadata">
-  <soapenv:Header>
-    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
-  </soapenv:Header>
-  <soapenv:Body>
-    <met:checkRetrieveStatus>
-      <met:asyncProcessId>{async_id}</met:asyncProcessId>
-      <met:includeZip>true</met:includeZip>
-    </met:checkRetrieveStatus>
-  </soapenv:Body>
-</soapenv:Envelope>"""
 
 
 # ── Logging ───────────────────────────────────────────────────────────────────
@@ -453,304 +364,101 @@ class SalesforceDataCloudService:
         return ["default"]
 
     @_retrying
-    def _soap_post(self, body: str, action: str):
-        url = f"{self.instance_url}/services/Soap/m/{SF_API_VERSION}"
-        resp = requests.post(
-            url,
-            data=body.encode("utf-8"),
-            headers={"Content-Type": "text/xml", "SOAPAction": action},
+    def _fetch_dmo_mappings(self, dmo_developer_name: str) -> list:
+        """
+        Fetch DLO->DMO source/target mappings for one DMO via the Data Cloud REST API.
+
+        Read-only: uses the same OAuth/API scope as the other /ssot endpoints, with NO
+        SOAP Metadata API and NO 'Modify Metadata' permission. A 404 (NOT_FOUND) means
+        the DMO has no source mappings and is returned as an empty list (normal — most
+        installed standard DMOs are unmapped).
+        """
+        resp = requests.get(
+            f"{self.instance_url}/services/data/v{SF_API_VERSION}/ssot/data-model-object-mappings",
+            headers={"Authorization": f"Bearer {self._token}"},
+            params={"dmoDeveloperName": dmo_developer_name},
             verify=True,
-            timeout=60,
+            timeout=30,
         )
+        if resp.status_code == 404:
+            return []
         resp.raise_for_status()
-        root = SafeET.fromstring(resp.text)
-        fault = root.find(".//soapenv:Fault", SOAP_NS)
-        if fault is not None:
-            code = fault.findtext("faultcode", default="unknown")
-            msg  = _safe_snippet(fault.findtext("faultstring", default="no detail"))
-            raise RuntimeError(f"Salesforce SOAP fault [{code}]: {msg}")
-        return root
-
-    def _list_ostm_names(self) -> list[str]:
-        """Call listMetadata to get all ObjectSourceTargetMap record names. Completes in <1s."""
-        envelope = _LIST_METADATA_ENVELOPE.format(
-            session_id=escape(self._token),
-            api_version=escape(SF_API_VERSION),
-        )
-        root = self._soap_post(envelope, action="listMetadata")
-        return [
-            el.text
-            for el in root.findall(".//{http://soap.sforce.com/2006/04/metadata}fullName")
-            if el.text
-        ]
-
-    def _submit_retrieve(self, members_xml: str) -> str:
-        """Submit a retrieve job for specific members and return the async job ID."""
-        envelope = _RETRIEVE_BATCH_ENVELOPE.format(
-            session_id=escape(self._token),
-            api_version=escape(SF_API_VERSION),
-            members=members_xml,
-        )
-        root = self._soap_post(envelope, action="retrieve")
-        async_id_el = root.find(".//met:id", SOAP_NS)
-        if async_id_el is None:
-            fault_el = root.find(".//met:error", SOAP_NS)
-            detail = _safe_snippet(fault_el.findtext("faultstring") or fault_el.findtext("message") or "(no detail)") if fault_el is not None else "no error element"
-            raise RuntimeError(f"Retrieve returned no async ID. Detail: {detail}")
-        if not async_id_el.text:
-            raise RuntimeError("Salesforce returned an empty async job ID for the metadata retrieve.")
-        return async_id_el.text
-
-    def _poll_retrieve(self, async_id: str, label: str) -> bytes:
-        """Poll a retrieve job until complete and return ZIP bytes."""
-        consecutive_failures = 0
-        max_consecutive = 5
-
-        for attempt in range(METADATA_MAX_POLLS):
-            status_body = _STATUS_ENVELOPE.format(
-                session_id=escape(self._token),
-                async_id=escape(async_id),
-            )
-            try:
-                status_root = self._soap_post(status_body, action="checkRetrieveStatus")
-                consecutive_failures = 0
-            except (requests.exceptions.RequestException, RuntimeError) as exc:
-                consecutive_failures += 1
-                log.warning(
-                    "  %s poll %d failed (consecutive=%d/%d): %s",
-                    label, attempt + 1, consecutive_failures, max_consecutive, exc,
-                )
-                if consecutive_failures >= max_consecutive:
-                    raise RuntimeError(
-                        f"Metadata poll failed {max_consecutive} consecutive times. "
-                        f"Last error: {exc}. Async job ID: {async_id}"
-                    ) from exc
-                time.sleep(METADATA_POLL_INTERVAL)
-                continue
-
-            done_el  = status_root.find(".//met:done",   SOAP_NS)
-            state_el = status_root.find(".//met:status", SOAP_NS)
-            state    = (state_el.text or "unknown") if state_el is not None else "unknown"
-
-            if done_el is None:
-                log.warning("  %s poll %d: missing <done> element — treating as not done", label, attempt + 1)
-
-            if done_el is not None and done_el.text == "true":
-                if state == "Failed":
-                    err_code = status_root.findtext(".//met:errorStatusCode", default="", namespaces=SOAP_NS)
-                    err_msg  = _safe_snippet(status_root.findtext(".//met:errorMessage", default="", namespaces=SOAP_NS))
-                    raise RuntimeError(f"Salesforce retrieve job failed [{err_code}]: {err_msg}")
-                zip_el = status_root.find(".//met:zipFile", SOAP_NS)
-                if zip_el is None or not zip_el.text:
-                    raise RuntimeError("Retrieve completed but ZIP payload is empty.")
-                return base64.b64decode(zip_el.text)
-
-            log.debug("  %s poll %d/%d status=%s", label, attempt + 1, METADATA_MAX_POLLS, state)
-            if attempt < METADATA_MAX_POLLS - 1:
-                time.sleep(METADATA_POLL_INTERVAL)
-
-        raise TimeoutError(
-            f"Batch retrieve did not complete within "
-            f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s. Async job ID: {async_id}. "
-            f"Increase METADATA_MAX_POLLS or METADATA_POLL_INTERVAL, or check Salesforce org status."
-        )
-
-    def fetch_metadata(self) -> bytes:
-        t0 = time.monotonic()
-        log.info("Step 3: Retrieving ObjectSourceTargetMap metadata from Salesforce")
-
-        # Fast list to discover all record names (~0.5s)
-        names = self._list_ostm_names()
-        if not names:
-            log.error(
-                "  listMetadata returned 0 ObjectSourceTargetMap records. "
-                "This means either (a) the org has no DLO→DMO mappings yet, or "
-                "(b) the connected Salesforce user lacks Metadata API read access. "
-                "Verify permissions with sf_diagnostic.py before re-running."
-            )
-            buf = io.BytesIO()
-            with zipfile.ZipFile(buf, "w"):
-                pass
-            return buf.getvalue()
-
-        batches = [names[i:i + METADATA_BATCH_SIZE] for i in range(0, len(names), METADATA_BATCH_SIZE)]
-        total_batches = len(batches)
-        log.info(
-            "  Found %d ObjectSourceTargetMap record(s) — retrieving in %d batch(es) of up to %d",
-            len(names), total_batches, METADATA_BATCH_SIZE,
-        )
-
-        combined_buf = io.BytesIO()
-        batch_times: list[float] = []
-        cumulative_uncompressed = 0
-
-        with zipfile.ZipFile(combined_buf, "w", zipfile.ZIP_DEFLATED) as combined_zip:
-            for i, batch in enumerate(batches):
-                batch_num = i + 1
-                batch_t0 = time.monotonic()
-                members_xml = "\n            ".join(
-                    f"<met:members>{escape(n)}</met:members>" for n in batch
-                )
-                async_id = self._submit_retrieve(members_xml)
-                log.debug("  Batch %d/%d submitted (id=%s)", batch_num, total_batches, async_id)
-
-                zip_bytes = self._poll_retrieve(async_id, label=f"Batch {batch_num}/{total_batches}")
-                batch_elapsed = time.monotonic() - batch_t0
-                batch_times.append(batch_elapsed)
-
-                # Rolling average ETA over last 5 batches
-                window = batch_times[-5:]
-                avg = sum(window) / len(window)
-                remaining = total_batches - batch_num
-                if remaining > 0:
-                    log.info(
-                        "  Batch %d/%d complete (%d record(s), %.1fs) — est. %s remaining",
-                        batch_num, total_batches, len(batch), batch_elapsed, _format_eta(avg * remaining),
-                    )
-                else:
-                    log.info(
-                        "  Batch %d/%d complete (%d record(s), %.1fs)",
-                        batch_num, total_batches, len(batch), batch_elapsed,
-                    )
-
-                with zipfile.ZipFile(io.BytesIO(zip_bytes)) as batch_zf:
-                    if len(batch_zf.namelist()) > ZIP_MAX_FILES:
-                        raise RuntimeError(
-                            f"Batch {batch_num} ZIP contains more than {ZIP_MAX_FILES} files — "
-                            "aborting to prevent decompression bomb."
-                        )
-                    batch_uncompressed = sum(info.file_size for info in batch_zf.infolist())
-                    if batch_uncompressed > ZIP_MAX_BYTES:
-                        raise RuntimeError(
-                            f"Batch {batch_num} ZIP uncompressed size "
-                            f"{batch_uncompressed / 1024 / 1024:.0f}MB exceeds safety limit "
-                            f"of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
-                        )
-                    cumulative_uncompressed += batch_uncompressed
-                    if cumulative_uncompressed > ZIP_MAX_BYTES:
-                        raise RuntimeError(
-                            f"Cumulative uncompressed size across {batch_num} batch(es) "
-                            f"({cumulative_uncompressed / 1024 / 1024:.0f}MB) exceeds safety limit "
-                            f"of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
-                        )
-                    for name in batch_zf.namelist():
-                        if name.endswith("package.xml"):
-                            continue  # skip sidecar manifest — one copy already present
-                        if "\x00" in name:
-                            log.warning("  Skipping ZIP entry with null byte in filename")
-                            continue
-                        # Strip leading slashes, normalize backslashes, and remove any
-                        # path-traversal (. and ..) components before writing to the combined ZIP.
-                        safe_name = name.lstrip("/").replace("\\", "/")
-                        parts = [p for p in safe_name.split("/") if p and p not in (".", "..")]
-                        safe_name = "/".join(parts)
-                        if not safe_name:
-                            continue
-                        combined_zip.writestr(safe_name, batch_zf.read(name))
-
-        log.info("  All %d record(s) retrieved in %.1fs", len(names), time.monotonic() - t0)
-        return combined_buf.getvalue()
-
-    def parse_edges(self, zip_bytes: bytes, fallback_dataspace: str) -> list:
-        """
-        Parse DLO->DMO edges from the ObjectSourceTargetMap ZIP payload.
-
-        Data space resolution order per record:
-          1. <dataSpace> XML field (preferred — present in most orgs)
-          2. fallback_dataspace (SF_DEFAULT_DATA_SPACE env var, default: 'default')
-        """
-        t0 = time.monotonic()
-        log.info("Step 4: Parsing DLO->DMO edges from metadata")
-        edges = []
-        skipped = 0
-        xml_had_dataspace = 0
-
-        buf = io.BytesIO(zip_bytes)
         try:
-            zf_handle = zipfile.ZipFile(buf)
-        except zipfile.BadZipFile as exc:
-            raise RuntimeError(f"Retrieved payload is not a valid ZIP: {exc}") from exc
-
-        with zf_handle as zf:
-            all_names = zf.namelist()
-            if len(all_names) > ZIP_MAX_FILES:
-                raise RuntimeError(
-                    f"ZIP contains {len(all_names)} files — exceeds safety limit of {ZIP_MAX_FILES}. "
-                    "Aborting to prevent decompression bomb."
-                )
-            total_uncompressed = sum(i.file_size for i in zf.infolist())
-            if total_uncompressed > ZIP_MAX_BYTES:
-                raise RuntimeError(
-                    f"ZIP total uncompressed size {total_uncompressed / 1024 / 1024:.0f}MB "
-                    f"exceeds safety limit of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
-                )
-
-            xml_files = [n for n in all_names if n.endswith(".objectSourceTargetMap")]
-            meta_xml_count = sum(
-                1 for n in all_names if n.endswith(".objectSourceTargetMap-meta.xml")
-            )
-            if meta_xml_count:
-                log.debug(
-                    "  Skipping %d .objectSourceTargetMap-meta.xml file(s) (metadata sidecar, not parsed)",
-                    meta_xml_count,
-                )
-
-            if not xml_files:
-                raise RuntimeError(
-                    "ZIP contained no .objectSourceTargetMap files. "
-                    "Check that the retrieve succeeded and the metadata type name is correct. "
-                    "Run with LOG_LEVEL=DEBUG to inspect the ZIP contents."
-                )
-            log.info("  Found %d ObjectSourceTargetMap record(s)", len(xml_files))
-
-            for name in xml_files:
-                with zf.open(name) as f:
-                    try:
-                        root = SafeET.parse(f).getroot()
-                    except _ETParseError as exc:
-                        log.warning("  Skipping %s: XML parse error: %s", name, exc)
-                        skipped += 1
-                        continue
-
-                source = root.findtext("sf:sourceObjectName", namespaces=OSTM_NS)
-                target = root.findtext("sf:targetObjectName", namespaces=OSTM_NS)
-
-                if not source or not target:
-                    log.warning("  Skipping %s: missing sourceObjectName or targetObjectName", name)
-                    skipped += 1
-                    continue
-
-                if not (source.endswith("__dll") and target.endswith("__dlm")):
-                    continue
-
-                data_space = root.findtext("sf:dataSpace", namespaces=OSTM_NS)
-                if data_space:
-                    xml_had_dataspace += 1
-                else:
-                    data_space = fallback_dataspace
-
-                edges.append({"source": source, "target": target, "data_space": data_space})
-
-        buf.close()  # ZipFile.__exit__ does not close the underlying BytesIO buffer
-
-        if skipped and skipped == len(xml_files):
+            body = resp.json()
+        except ValueError as exc:
             raise RuntimeError(
-                f"All {skipped} ObjectSourceTargetMap record(s) failed to parse. "
-                "Check Salesforce connectivity and metadata type availability."
-            )
-        if skipped:
-            log.warning("  Skipped %d record(s) due to parse errors", skipped)
-        if xml_had_dataspace:
-            log.info("  Data space resolved from XML: %d/%d edge(s)", xml_had_dataspace, len(edges))
-        if xml_had_dataspace < len(edges):
-            no_space_count = len(edges) - xml_had_dataspace
+                f"Non-JSON response from data-model-object-mappings for "
+                f"{dmo_developer_name!r} (HTTP {resp.status_code}): {_safe_snippet(resp.text)}"
+            ) from exc
+        return body.get("objectSourceTargetMaps") or []
+
+    def fetch_dlo_dmo_edges(self, dmo_specs: list, fallback_dataspace: str) -> list:
+        """
+        Fetch DLO->DMO lineage edges via the Data Cloud REST mapping endpoint.
+
+        `dmo_specs` is a list of (dmo_developer_name, preliminary_data_space) tuples —
+        the DMOs Monte Carlo actually catalogs — so we issue one read-only GET per
+        catalogued DMO rather than enumerating every installed standard DMO.
+
+        Replaces the former SOAP Metadata API retrieve of ObjectSourceTargetMap. The
+        REST record ({sourceEntityDeveloperName, targetEntityDeveloperName, status})
+        carries identical DLO->DMO information with no 'Modify Metadata' permission.
+        Data space here is preliminary; validate_edges() resolves the authoritative
+        value from the MC catalog dataset field.
+        """
+        t0 = time.monotonic()
+        log.info(
+            "Step 4: Retrieving DLO->DMO mappings via Data Cloud REST API "
+            "(read-only; %d catalogued DMO(s))",
+            len(dmo_specs),
+        )
+        if not dmo_specs:
+            log.warning("  No catalogued DMOs to query — 0 DLO->DMO edges extracted.")
+            return []
+
+        edges: list = []
+        seen: set = set()
+        mapped = 0
+        errors = 0
+
+        max_workers = min(MAPPING_MAX_WORKERS, len(dmo_specs))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_spec = {
+                pool.submit(self._fetch_dmo_mappings, name): (name, space)
+                for name, space in dmo_specs
+            }
+            for fut in concurrent.futures.as_completed(future_to_spec):
+                dmo_name, prelim_space = future_to_spec[fut]
+                try:
+                    maps = fut.result()
+                except Exception as exc:  # noqa: BLE001 — one DMO must not abort the run
+                    errors += 1
+                    log.warning("  Mapping fetch failed for DMO '%s': %s", dmo_name, exc)
+                    continue
+                if not maps:
+                    continue
+                mapped += 1
+                for m in maps:
+                    source = m.get("sourceEntityDeveloperName") or ""
+                    target = m.get("targetEntityDeveloperName") or ""
+                    if not (source.endswith("__dll") and target.endswith("__dlm")):
+                        continue
+                    key = (source.lower(), target.lower())
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    edges.append({"source": source, "target": target, "data_space": prelim_space})
+
+        log.info(
+            "  %d DLO->DMO edge(s) extracted from %d mapped DMO(s) (%.1fs)",
+            len(edges), mapped, time.monotonic() - t0,
+        )
+        if errors:
             log.warning(
-                "  %d/%d edge(s) have no <dataSpace> in XML — using fallback '%s'. "
-                "If your org uses multiple data spaces, set SF_DEFAULT_DATA_SPACE to match "
-                "or contact your Salesforce admin to confirm the data space name.",
-                no_space_count, len(edges), fallback_dataspace,
+                "  %d DMO mapping fetch(es) errored and were skipped — edges for those "
+                "DMOs may be missing. Re-run (idempotent) once the transient issue clears.",
+                errors,
             )
-        log.info("  %d DLO->DMO edge(s) extracted (%.1fs)", len(edges), time.monotonic() - t0)
         return edges
 
     def _validate_same_origin(self, url: str) -> str:
@@ -1040,40 +748,63 @@ class SalesforceDataCloudLineageService:
             return entry[0]
         return entry
 
-    def validate_edges(self, edges: list) -> list:
+    def fetch_catalog(self) -> dict:
         """
-        Fetch all tables for the warehouse from MC in bulk, then validate each edge.
-        Resolves the DMO's authoritative data space first, then resolves the DLO
-        preferring the DMO's data space — so DLOs shared across multiple data spaces
-        (e.g. a DLO added to both 'default' and 'unified_knowledge') resolve to the
-        correct pairing rather than the XML fallback. Edges where either table is
-        missing from the MC catalog, or where the DLO is not available in the DMO's
-        data space, are removed and logged. Returns the validated subset ready for push.
+        Fetch all tables for the warehouse from MC (bulk, paginated, scoped by dwId).
+        Fetched once and reused for both DMO enumeration and edge validation.
         """
-        if not edges:
-            return edges
-
-        log.info("Step 4b: Validating DLO and DMO tables exist in Monte Carlo catalog")
+        log.info("Step 3: Fetching Monte Carlo catalog for warehouse %s", self.resource_uuid)
         t0 = time.monotonic()
-
         try:
             mc_catalog = self._fetch_mc_catalog()
         except requests.exceptions.HTTPError as exc:
             status = exc.response.status_code if exc.response is not None else "unknown"
             raise RuntimeError(
-                f"MC catalog fetch returned HTTP {status}. "
-                "Check MCD_ID/MCD_TOKEN."
+                f"MC catalog fetch returned HTTP {status}. Check MCD_ID/MCD_TOKEN."
             ) from exc
         except requests.exceptions.RequestException as exc:
             raise RuntimeError(
                 f"Network error fetching MC catalog: {exc}. "
                 "Check connectivity to https://api.getmontecarlo.com"
             ) from exc
-
         log.info(
             "  Fetched %d table(s) from MC catalog (%.1fs)",
             len(mc_catalog), time.monotonic() - t0,
         )
+        return mc_catalog
+
+    def catalogued_dmos(self, mc_catalog: dict, fallback_dataspace: str) -> list:
+        """
+        Return [(dmo_developer_name, preliminary_data_space)] for every DMO (__dlm) in
+        the MC catalog — the set of DMOs to query for DLO->DMO mappings. Iterating the
+        connector's own catalogued DMOs (rather than the full installed-DMO list) keeps
+        the REST fetch to one GET per relevant DMO. The preliminary data space is the
+        DMO's catalog dataset (authoritative); validate_edges confirms it downstream.
+        """
+        specs = []
+        for name, entry in mc_catalog.items():
+            if not name.endswith("__dlm"):
+                continue
+            space = entry if isinstance(entry, str) else fallback_dataspace
+            specs.append((name, space))
+        log.info("  %d catalogued DMO(s) to query for DLO->DMO mappings", len(specs))
+        return specs
+
+    def validate_edges(self, edges: list, mc_catalog: dict) -> list:
+        """
+        Validate each edge against the (pre-fetched) MC catalog.
+        Resolves the DMO's authoritative data space first, then resolves the DLO
+        preferring the DMO's data space — so DLOs shared across multiple data spaces
+        (e.g. a DLO added to both 'default' and 'unified_knowledge') resolve to the
+        correct pairing rather than the fallback. Edges where either table is missing
+        from the MC catalog, or where the DLO is not available in the DMO's data space,
+        are removed and logged. Returns the validated subset ready for push.
+        """
+        if not edges:
+            return edges
+
+        log.info("Step 4b: Validating DLO and DMO tables exist in Monte Carlo catalog")
+        t0 = time.monotonic()
 
         unique_names = sorted({e["source"] for e in edges} | {e["target"] for e in edges})
         missing_set: set = set()
@@ -1359,10 +1090,13 @@ def main() -> None:
                 fallback_space,
             )
 
-        # Steps 3-4b: DLO→DMO
-        zip_bytes = sf_svc.fetch_metadata()
-        dlo_edges = sf_svc.parse_edges(zip_bytes, fallback_space)
-        dlo_edges = lineage_svc.validate_edges(dlo_edges)
+        # Steps 3-4b: DLO→DMO via the read-only Data Cloud REST mapping endpoint.
+        # Fetch the MC catalog once, enumerate the catalogued DMOs, GET each DMO's
+        # mappings (no SOAP, no Modify Metadata), then validate against the same catalog.
+        mc_catalog = lineage_svc.fetch_catalog()
+        dmo_specs = lineage_svc.catalogued_dmos(mc_catalog, fallback_space)
+        dlo_edges = sf_svc.fetch_dlo_dmo_edges(dmo_specs, fallback_space)
+        dlo_edges = lineage_svc.validate_edges(dlo_edges, mc_catalog)
 
         # Steps 5-6: DMO→CIO (skipped if --skip-cio)
         # CIO catalog validation: DMO source tables were already validated in step 4b.

--- a/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/push_lineage.py
@@ -352,8 +352,8 @@ class SalesforceDataCloudService:
             log.warning(
                 "  Dataspace query returned 403 Forbidden — the connected app may lack "
                 "'Manage Data Cloud' or 'API Access' permissions. "
-                "Salesforce error: %s. Falling back to 'default'. "
-                "Edges without <dataSpace> in XML may land in the wrong data space.",
+                "Salesforce error: %s. Falling back to 'default' — edge data spaces are "
+                "still resolved from the MC catalog dataset field during validation.",
                 _safe_snippet(resp.text),
             )
         else:
@@ -372,6 +372,12 @@ class SalesforceDataCloudService:
         SOAP Metadata API and NO 'Modify Metadata' permission. A 404 (NOT_FOUND) means
         the DMO has no source mappings and is returned as an empty list (normal — most
         installed standard DMOs are unmapped).
+
+        dmoDeveloperName is matched case-insensitively by the endpoint: verified live that
+        the lowercased MC-catalog key (e.g. 'ssot__account__dlm') resolves identically to
+        the canonical-case name ('ssot__Account__dlm'), and the extracted edge count matches
+        the legacy SOAP path exactly — so passing the catalog's lowercased DMO name here
+        does not drop any mappings.
         """
         resp = requests.get(
             f"{self.instance_url}/services/data/v{SF_API_VERSION}/ssot/data-model-object-mappings",
@@ -392,7 +398,7 @@ class SalesforceDataCloudService:
             ) from exc
         return body.get("objectSourceTargetMaps") or []
 
-    def fetch_dlo_dmo_edges(self, dmo_specs: list, fallback_dataspace: str) -> list:
+    def fetch_dlo_dmo_edges(self, dmo_specs: list) -> list:
         """
         Fetch DLO->DMO lineage edges via the Data Cloud REST mapping endpoint.
 
@@ -739,13 +745,16 @@ class SalesforceDataCloudLineageService:
         if isinstance(entry, list):
             if preferred_data_space and preferred_data_space in entry:
                 return preferred_data_space
+            # Catalogued in multiple data spaces and the mapping's space can't be
+            # disambiguated — return None so the caller skips the edge rather than
+            # guessing a data space (a wrong-space edge is worse than a missing one).
             log.warning(
-                "  Table '%s' found in multiple data spaces in MC catalog: %s — "
-                "using '%s'. If edges land in the wrong data space, check which "
-                "data space the DLO→DMO mapping belongs to and set SF_DEFAULT_DATA_SPACE.",
-                table_name, entry, entry[0],
+                "  Table '%s' is catalogued in multiple data spaces %s and the mapping's "
+                "data space could not be disambiguated — skipping its edge(s). Set "
+                "SF_DEFAULT_DATA_SPACE to the intended data space to resolve.",
+                table_name, entry,
             )
-            return entry[0]
+            return None
         return entry
 
     def fetch_catalog(self) -> dict:
@@ -844,7 +853,7 @@ class SalesforceDataCloudLineageService:
             # Resolve DMO first to get its authoritative data space, then resolve
             # the DLO preferring the DMO's data space. DLOs can be explicitly shared
             # across data spaces in Salesforce; a DLO in both 'default' and
-            # 'unified_knowledge' should pair with the DMO's space, not the XML fallback.
+            # 'unified_knowledge' should pair with the DMO's space, not a fallback value.
             tgt_space = self._resolve_catalog(mc_catalog, e["target"], preferred_data_space=preferred)
             if tgt_space is None:
                 catalog_skips += 1
@@ -1081,12 +1090,14 @@ def main() -> None:
         sf_svc.authenticate()
 
         data_spaces = sf_svc.get_dataspaces()
-        # Single data space: use it directly. Multiple: XML <dataSpace> is authoritative;
-        # default_dataspace (SF_DEFAULT_DATA_SPACE) is a last-resort fallback only.
+        # Single data space: use it directly. Multiple: the MC catalog's dataset field is
+        # authoritative (resolved in validate_edges); default_dataspace
+        # (SF_DEFAULT_DATA_SPACE) is only a last-resort preliminary value.
         fallback_space = data_spaces[0] if len(data_spaces) == 1 else default_dataspace
         if len(data_spaces) > 1:
             log.info(
-                "  Multiple data spaces — DLO records without <dataSpace> will use '%s'",
+                "  Multiple data spaces — DMOs the MC catalog can't place in a single "
+                "data space will use '%s' as a preliminary value",
                 fallback_space,
             )
 
@@ -1095,7 +1106,7 @@ def main() -> None:
         # mappings (no SOAP, no Modify Metadata), then validate against the same catalog.
         mc_catalog = lineage_svc.fetch_catalog()
         dmo_specs = lineage_svc.catalogued_dmos(mc_catalog, fallback_space)
-        dlo_edges = sf_svc.fetch_dlo_dmo_edges(dmo_specs, fallback_space)
+        dlo_edges = sf_svc.fetch_dlo_dmo_edges(dmo_specs)
         dlo_edges = lineage_svc.validate_edges(dlo_edges, mc_catalog)
 
         # Steps 5-6: DMO→CIO (skipped if --skip-cio)

--- a/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
+++ b/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
@@ -17,6 +17,7 @@ Required env vars (or set in .env):
 import concurrent.futures
 import ipaddress
 import os
+import re
 import socket
 import sys
 import time
@@ -29,6 +30,15 @@ from dotenv import load_dotenv
 load_dotenv(dotenv_path=Path(__file__).parent / ".env")
 
 SF_API_VERSION = "62.0"
+
+# Redact long token-like strings before printing API response bodies. This script is
+# meant to be shared with Salesforce admins and its output pasted into tickets/Slack,
+# so mirror push_lineage.py's _safe_snippet and never echo raw bodies verbatim.
+_TOKEN_RE = re.compile(r"[A-Za-z0-9._\-]{60,}")
+
+
+def _safe(text, max_len=200):
+    return _TOKEN_RE.sub("[…]", text or "")[:max_len]
 
 
 def _sep(label=""):
@@ -56,7 +66,7 @@ def check_auth(instance_url, client_id, client_secret):
     try:
         data = resp.json()
     except ValueError:
-        _fail(f"Non-JSON response from auth endpoint (HTTP {resp.status_code}): {resp.text[:200]}")
+        _fail(f"Non-JSON response from auth endpoint (HTTP {resp.status_code}): {_safe(resp.text)}")
         sys.exit(1)
     if "error" in data:
         _fail(f"Auth failed: {data.get('error')} — {data.get('error_description')}")
@@ -250,13 +260,13 @@ def check_calculated_insights(instance_url, token):
             return
 
         if resp.status_code != 200:
-            _fail(f"HTTP {resp.status_code} (page {page}): {resp.text[:200]}")
+            _fail(f"HTTP {resp.status_code} (page {page}): {_safe(resp.text)}")
             return
 
         try:
             data = resp.json()
         except ValueError:
-            _fail(f"Non-JSON response (page {page}): {resp.text[:200]}")
+            _fail(f"Non-JSON response (page {page}): {_safe(resp.text)}")
             return
 
         collection = data.get("collection", {})
@@ -278,11 +288,11 @@ def check_calculated_insights(instance_url, token):
             parsed_next = urlparse(raw_next)
             if not parsed_next.scheme:
                 if not raw_next.startswith("/"):
-                    _fail(f"Unexpected relative nextPageUrl (does not start with '/'): {raw_next[:200]!r} — pagination stopped, CIO list above may be incomplete.")
+                    _fail(f"Unexpected relative nextPageUrl (does not start with '/'): {_safe(raw_next)!r} — pagination stopped, CIO list above may be incomplete.")
                     return
                 next_url = f"{instance_url.rstrip('/')}{raw_next}"
             elif parsed_next.scheme != "https" or parsed_next.hostname != parsed_base.hostname:
-                _fail(f"Cross-origin or non-HTTPS nextPageUrl: {raw_next[:200]!r} — pagination stopped, CIO list above may be incomplete.")
+                _fail(f"Cross-origin or non-HTTPS nextPageUrl: {_safe(raw_next)!r} — pagination stopped, CIO list above may be incomplete.")
                 return
             else:
                 next_url = raw_next

--- a/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
+++ b/examples/push-ingestion/salesforce-data-cloud/sf_diagnostic.py
@@ -6,7 +6,7 @@ Validates that all Salesforce APIs used by the lineage push script are
 accessible and reports timing/volume data. No Monte Carlo credentials needed.
 
 Usage:
-  pip install requests python-dotenv defusedxml
+  pip install requests python-dotenv
   python3 sf_diagnostic.py
 
 Required env vars (or set in .env):
@@ -14,124 +14,21 @@ Required env vars (or set in .env):
   SF_CLIENT_ID     — Connected app consumer key
   SF_CLIENT_SECRET — Connected app consumer secret
 """
-import base64
-import io
+import concurrent.futures
 import ipaddress
 import os
 import socket
 import sys
 import time
-import zipfile
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-from defusedxml.ElementTree import ParseError as _ETParseError
-from xml.sax.saxutils import escape
 
 import requests
 from dotenv import load_dotenv
 
-try:
-    import defusedxml.ElementTree as SafeET
-except ImportError as err:
-    sys.exit(
-        f"ERROR: defusedxml is not installed. Run: pip install defusedxml>=0.7.1\n  ({err})"
-    )
-
 load_dotenv(dotenv_path=Path(__file__).parent / ".env")
 
 SF_API_VERSION = "62.0"
-ZIP_MAX_FILES  = 10_000
-ZIP_MAX_BYTES  = 500 * 1024 * 1024  # 500 MB
-
-
-def _parse_positive_int(name: str, default: int) -> int:
-    raw = os.environ.get(name, str(default))
-    try:
-        val = int(raw)
-        if val < 1:
-            raise ValueError("must be >= 1")
-        return val
-    except ValueError as exc:
-        print(f"[FAIL] Invalid {name}={raw!r}: {exc}")
-        sys.exit(1)
-
-
-def _parse_positive_float(name: str, default: float) -> float:
-    raw = os.environ.get(name, str(default))
-    try:
-        val = float(raw)
-        if val <= 0:
-            raise ValueError("must be > 0")
-        return val
-    except ValueError as exc:
-        print(f"[FAIL] Invalid {name}={raw!r}: {exc}")
-        sys.exit(1)
-
-
-METADATA_BATCH_SIZE    = _parse_positive_int("METADATA_BATCH_SIZE", 10)
-METADATA_MAX_POLLS     = _parse_positive_int("METADATA_MAX_POLLS", 120)
-METADATA_POLL_INTERVAL = _parse_positive_float("METADATA_POLL_INTERVAL", 5.0)
-
-SOAP_NS = {
-    "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
-    "met":     "http://soap.sforce.com/2006/04/metadata",
-}
-OSTM_NS = {"sf": "http://soap.sforce.com/2006/04/metadata"}
-
-_LIST_METADATA_ENVELOPE = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:met="http://soap.sforce.com/2006/04/metadata">
-  <soapenv:Header>
-    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
-  </soapenv:Header>
-  <soapenv:Body>
-    <met:listMetadata>
-      <met:queries><met:type>ObjectSourceTargetMap</met:type></met:queries>
-      <met:asOfVersion>{api_version}</met:asOfVersion>
-    </met:listMetadata>
-  </soapenv:Body>
-</soapenv:Envelope>"""
-
-_RETRIEVE_BATCH_ENVELOPE = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:met="http://soap.sforce.com/2006/04/metadata">
-  <soapenv:Header>
-    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
-  </soapenv:Header>
-  <soapenv:Body>
-    <met:retrieve>
-      <met:retrieveRequest>
-        <met:apiVersion>{api_version}</met:apiVersion>
-        <met:unpackaged>
-          <met:types>
-            {members}
-            <met:name>ObjectSourceTargetMap</met:name>
-          </met:types>
-        </met:unpackaged>
-      </met:retrieveRequest>
-    </met:retrieve>
-  </soapenv:Body>
-</soapenv:Envelope>"""
-
-_STATUS_ENVELOPE = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope
-    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:met="http://soap.sforce.com/2006/04/metadata">
-  <soapenv:Header>
-    <met:SessionHeader><met:sessionId>{session_id}</met:sessionId></met:SessionHeader>
-  </soapenv:Header>
-  <soapenv:Body>
-    <met:checkRetrieveStatus>
-      <met:asyncProcessId>{async_id}</met:asyncProcessId>
-      <met:includeZip>true</met:includeZip>
-    </met:checkRetrieveStatus>
-  </soapenv:Body>
-</soapenv:Envelope>"""
 
 
 def _sep(label=""):
@@ -145,68 +42,6 @@ def _sep(label=""):
 def _ok(msg):  print(f"  [OK]   {msg}")
 def _warn(msg): print(f"  [WARN] {msg}")
 def _fail(msg): print(f"  [FAIL] {msg}")
-
-
-def _format_eta(seconds: float) -> str:
-    if seconds < 60:
-        return f"{seconds:.0f}s"
-    mins, secs = divmod(int(seconds), 60)
-    return f"{mins}m {secs:02d}s"
-
-
-def _soap_post(url: str, envelope: str, action: str):
-    resp = requests.post(
-        url,
-        data=envelope.encode("utf-8"),
-        headers={"Content-Type": "text/xml", "SOAPAction": action},
-        timeout=60,
-        verify=True,
-    )
-    resp.raise_for_status()
-    root = SafeET.fromstring(resp.text)
-    fault = root.find(".//soapenv:Fault", SOAP_NS)
-    if fault is not None:
-        code = fault.findtext("faultcode", default="unknown")
-        msg  = (fault.findtext("faultstring", default="no detail") or "")[:200]
-        _fail(f"SOAP fault [{code}]: {msg}")
-        sys.exit(1)
-    return root
-
-
-def _poll_batch(url: str, token: str, async_id: str, label: str) -> bytes:
-    for attempt in range(METADATA_MAX_POLLS):
-        status_body = _STATUS_ENVELOPE.format(
-            session_id=escape(token), async_id=escape(async_id)
-        )
-        status_root = _soap_post(url, status_body, action="checkRetrieveStatus")
-
-        done_el  = status_root.find(".//met:done",   SOAP_NS)
-        state_el = status_root.find(".//met:status", SOAP_NS)
-        state    = state_el.text if state_el is not None else "unknown"
-
-        if done_el is not None and done_el.text == "true":
-            if state == "Failed":
-                err_code = status_root.findtext(".//met:errorStatusCode", default="", namespaces=SOAP_NS)
-                err_msg  = (status_root.findtext(".//met:errorMessage", default="", namespaces=SOAP_NS) or "")[:200]
-                _fail(f"Retrieve job failed [{err_code}]: {err_msg}")
-                sys.exit(1)
-            zip_el = status_root.find(".//met:zipFile", SOAP_NS)
-            if zip_el is None or not zip_el.text:
-                _fail("Retrieve completed but ZIP payload is empty")
-                sys.exit(1)
-            return base64.b64decode(zip_el.text)
-
-        if attempt % 5 == 0:
-            elapsed_msg = f"attempt {attempt + 1}/{METADATA_MAX_POLLS}, status={state}"
-            print(f"  [....] {label}: polling... {elapsed_msg}")
-        time.sleep(METADATA_POLL_INTERVAL)
-
-    _fail(
-        f"Retrieve did not complete within "
-        f"{METADATA_MAX_POLLS * METADATA_POLL_INTERVAL:.0f}s ({label}). "
-        f"Try increasing METADATA_MAX_POLLS (current: {METADATA_MAX_POLLS})."
-    )
-    sys.exit(1)
 
 
 def check_auth(instance_url, client_id, client_secret):
@@ -258,186 +93,125 @@ def check_data_spaces(instance_url, token):
         _ok(f"  • {s}")
     if len(spaces) > 1:
         _warn(
-            "Multiple data spaces found. The lineage push script will use the data space "
-            "recorded in each ObjectSourceTargetMap XML record. If a record has no <dataSpace> "
-            "field, it will fall back to SF_DEFAULT_DATA_SPACE (default: 'default'). "
-            "Set SF_DEFAULT_DATA_SPACE if your primary data space has a different name."
+            "Multiple data spaces found. The push script resolves each edge's data space from "
+            "the Monte Carlo catalog (authoritative); SF_DEFAULT_DATA_SPACE (default: 'default') "
+            "is only a last-resort fallback. Set it if your primary data space has a different name."
         )
     return spaces
 
 
-def check_metadata_retrieve(instance_url, token):
-    _sep("3. SOAP Metadata API — ObjectSourceTargetMap retrieve")
+def _enumerate_dmos(instance_url, token, max_dmos=150):
+    """List Data Model Object developer names via the Data Cloud REST API (paginated).
 
-    url = f"{instance_url}/services/Soap/m/{SF_API_VERSION}"
+    Bounded by max_dmos: this endpoint returns every installed standard DMO (often
+    1,000+), so the diagnostic samples up to max_dmos just to prove read access
+    quickly. The push script drives off the Monte Carlo catalog (complete/authoritative).
+    """
+    dmos, seen, offset, limit = [], set(), 0, 50
+    for _ in range(400):  # safety cap
+        try:
+            resp = requests.get(
+                f"{instance_url}/services/data/v{SF_API_VERSION}/ssot/data-model-objects",
+                headers={"Authorization": f"Bearer {token}"},
+                params={"limit": limit, "offset": offset},
+                timeout=(10, 60), verify=True,
+            )
+        except requests.exceptions.RequestException as exc:
+            _warn(f"data-model-objects page at offset {offset} failed ({exc}) — "
+                  f"proceeding with the {len(dmos)} DMO(s) enumerated so far.")
+            break
+        if resp.status_code == 403:
+            return None
+        resp.raise_for_status()
+        page = resp.json().get("dataModelObject", []) or []
+        new = 0
+        for d in page:
+            name = d.get("name")
+            if name and name not in seen:
+                seen.add(name); dmos.append(name); new += 1
+        if len(dmos) >= max_dmos or len(page) < limit or new == 0:
+            break  # cap reached, last page, or offset not honored
+        offset += limit
+    return dmos[:max_dmos]
+
+
+def check_dlo_dmo_mappings(instance_url, token):
+    _sep("3. Data Cloud REST API — DLO->DMO mappings (read-only)")
     t0 = time.monotonic()
+    try:
+        max_dmos = max(1, int(os.environ.get("DIAG_MAX_DMOS", "150")))
+    except ValueError:
+        max_dmos = 150
+    dmos = _enumerate_dmos(instance_url, token, max_dmos=max_dmos)
+    if dmos is None:
+        _warn("HTTP 403 listing data model objects — the connected app lacks Data Cloud API access.")
+        _warn("Ensure the OAuth scope includes 'api' and the run-as user has a Data Cloud permission set.")
+        return
+    _ok(f"Enumerated {len(dmos)} data model object(s) in {time.monotonic() - t0:.1f}s")
+    if not dmos:
+        _warn("No data model objects returned — cannot check mappings.")
+        return
+    if len(dmos) >= max_dmos:
+        _warn(f"Sampled the first {max_dmos} DMO(s) to prove access (org has more — raise "
+              "DIAG_MAX_DMOS to check more). The push script uses the complete MC catalog.")
 
-    # Step 3a: list all record names via listMetadata (~0.5s)
-    list_envelope = _LIST_METADATA_ENVELOPE.format(
-        session_id=escape(token), api_version=escape(SF_API_VERSION)
+    _ok(f"Querying mappings for {len(dmos)} DMO(s) — read-only, no 'Modify Metadata' permission")
+    t1 = time.monotonic()
+    edges, errors, forbidden, checked = [], 0, False, 0
+
+    def _one(dmo):
+        r = requests.get(
+            f"{instance_url}/services/data/v{SF_API_VERSION}/ssot/data-model-object-mappings",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"dmoDeveloperName": dmo}, timeout=(10, 30), verify=True,
+        )
+        body = r.json() if r.headers.get("content-type", "").startswith("application/json") else None
+        return dmo, r.status_code, body
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+        futs = {pool.submit(_one, d): d for d in dmos}
+        for fut in concurrent.futures.as_completed(futs):
+            checked += 1
+            try:
+                dmo, sc, body = fut.result()
+            except Exception:
+                errors += 1
+                continue
+            if sc == 403:
+                forbidden = True
+                continue
+            if sc == 404:
+                continue  # DMO has no source mappings — normal
+            if sc != 200 or not isinstance(body, dict):
+                errors += 1
+                continue
+            for m in (body.get("objectSourceTargetMaps") or []):
+                src = m.get("sourceEntityDeveloperName") or ""
+                tgt = m.get("targetEntityDeveloperName") or ""
+                if src.endswith("__dll") and tgt.endswith("__dlm"):
+                    edges.append((src, tgt))
+
+    if forbidden:
+        _warn("HTTP 403 on data-model-object-mappings — the connected app cannot read DLO->DMO mappings.")
+        _warn("This endpoint uses the standard Data Cloud API scope (no Metadata API / Modify Metadata).")
+        return
+
+    edges = sorted(set(edges))
+    _ok(f"Queried {checked} DMO(s) in {time.monotonic() - t1:.1f}s")
+    _ok(f"DLO->DMO edges found: {len(edges)}")
+    if errors:
+        _warn(f"{errors} DMO mapping query(ies) returned an unexpected status and were skipped.")
+    if not edges:
+        _warn("No DLO->DMO mappings found. Confirm DLO->DMO mappings exist in your Data Cloud org.")
+        return
+    print()
+    print("  DLO -> DMO edges (data space is resolved from the MC catalog at push time):")
+    for src, tgt in edges:
+        print(f"    {src} -> {tgt}")
+    _warn(
+        "Note: this list is enumerated from /ssot/data-model-objects, which can omit a few "
+        "mapped DMOs; the push script drives off the Monte Carlo catalog and is authoritative."
     )
-    list_root = _soap_post(url, list_envelope, action="listMetadata")
-    names = [
-        el.text
-        for el in list_root.findall(".//{http://soap.sforce.com/2006/04/metadata}fullName")
-        if el.text
-    ]
-    elapsed = time.monotonic() - t0
-    _ok(f"listMetadata returned {len(names)} record(s) in {elapsed:.1f}s")
-
-    if not names:
-        _warn("No ObjectSourceTargetMap records found in org")
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w"):
-            pass
-        return buf.getvalue()
-
-    # Step 3b: retrieve in batches
-    batches = [names[i:i + METADATA_BATCH_SIZE] for i in range(0, len(names), METADATA_BATCH_SIZE)]
-    total_batches = len(batches)
-    _ok(f"Retrieving {len(names)} record(s) in {total_batches} batch(es) of up to {METADATA_BATCH_SIZE}")
-
-    combined_buf = io.BytesIO()
-    batch_times: list = []
-    cumulative_uncompressed = 0
-
-    with zipfile.ZipFile(combined_buf, "w", zipfile.ZIP_DEFLATED) as combined_zip:
-        for i, batch in enumerate(batches):
-            batch_num = i + 1
-            batch_t0 = time.monotonic()
-            members_xml = "\n            ".join(
-                f"<met:members>{escape(n)}</met:members>" for n in batch
-            )
-            retrieve_envelope = _RETRIEVE_BATCH_ENVELOPE.format(
-                session_id=escape(token),
-                api_version=escape(SF_API_VERSION),
-                members=members_xml,
-            )
-            retrieve_root = _soap_post(url, retrieve_envelope, action="retrieve")
-            async_id_el = retrieve_root.find(".//met:id", SOAP_NS)
-            if async_id_el is None or not async_id_el.text:
-                _fail(f"Batch {batch_num}: no async job ID returned")
-                sys.exit(1)
-            async_id = async_id_el.text
-
-            zip_bytes = _poll_batch(url, token, async_id, label=f"Batch {batch_num}/{total_batches}")
-            batch_elapsed = time.monotonic() - batch_t0
-            batch_times.append(batch_elapsed)
-
-            window = batch_times[-5:]
-            avg = sum(window) / len(window)
-            remaining = total_batches - batch_num
-            if remaining > 0:
-                _ok(
-                    f"Batch {batch_num}/{total_batches} complete ({len(batch)} record(s), "
-                    f"{batch_elapsed:.1f}s) — est. {_format_eta(avg * remaining)} remaining"
-                )
-            else:
-                _ok(f"Batch {batch_num}/{total_batches} complete ({len(batch)} record(s), {batch_elapsed:.1f}s)")
-
-            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as batch_zf:
-                if len(batch_zf.namelist()) > ZIP_MAX_FILES:
-                    _fail(
-                        f"Batch {batch_num} ZIP contains more than {ZIP_MAX_FILES} files — "
-                        "aborting to prevent decompression bomb."
-                    )
-                    sys.exit(1)
-                batch_uncompressed = sum(info.file_size for info in batch_zf.infolist())
-                if batch_uncompressed > ZIP_MAX_BYTES:
-                    _fail(
-                        f"Batch {batch_num} ZIP uncompressed size "
-                        f"{batch_uncompressed / 1024 / 1024:.0f}MB exceeds safety limit "
-                        f"of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
-                    )
-                    sys.exit(1)
-                cumulative_uncompressed += batch_uncompressed
-                if cumulative_uncompressed > ZIP_MAX_BYTES:
-                    _fail(
-                        f"Cumulative uncompressed size across {batch_num} batch(es) "
-                        f"({cumulative_uncompressed / 1024 / 1024:.0f}MB) exceeds safety limit "
-                        f"of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
-                    )
-                    sys.exit(1)
-                for name in batch_zf.namelist():
-                    if name.endswith("package.xml"):
-                        continue
-                    if "\x00" in name:
-                        print(f"  [WARN] Skipping ZIP entry with null byte in filename")
-                        continue
-                    safe_name = name.lstrip("/").replace("\\", "/")
-                    parts = [p for p in safe_name.split("/") if p and p not in (".", "..")]
-                    safe_name = "/".join(parts)
-                    if not safe_name:
-                        continue
-                    combined_zip.writestr(safe_name, batch_zf.read(name))
-
-    total_elapsed = time.monotonic() - t0
-    _ok(f"All {len(names)} record(s) retrieved in {total_elapsed:.1f}s")
-    return combined_buf.getvalue()
-
-
-def check_zip_contents(zip_bytes):
-    _sep("4. ObjectSourceTargetMap — parse DLO→DMO edges")
-    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
-        all_names = zf.namelist()
-        if len(all_names) > ZIP_MAX_FILES:
-            _fail(f"ZIP contains {len(all_names)} files — exceeds safety limit of {ZIP_MAX_FILES}.")
-            sys.exit(1)
-        total_uncompressed = sum(i.file_size for i in zf.infolist())
-        if total_uncompressed > ZIP_MAX_BYTES:
-            _fail(
-                f"ZIP total uncompressed size {total_uncompressed / 1024 / 1024:.0f}MB "
-                f"exceeds safety limit of {ZIP_MAX_BYTES / 1024 / 1024:.0f}MB."
-            )
-            sys.exit(1)
-
-        xml_files = [n for n in all_names if n.endswith(".objectSourceTargetMap")]
-        _ok(f"ZIP contains {len(all_names)} file(s) total")
-        _ok(f"ObjectSourceTargetMap records: {len(xml_files)}")
-
-        if not xml_files:
-            _warn("No .objectSourceTargetMap files found in ZIP")
-            _warn("Files present:")
-            for n in all_names[:20]:
-                _warn(f"  {n}")
-            return
-
-        edges = []
-        no_dataspace = 0
-        data_spaces_seen = set()
-
-        for name in xml_files:
-            with zf.open(name) as f:
-                try:
-                    root = SafeET.parse(f).getroot()
-                except _ETParseError:
-                    continue
-                source = root.findtext("sf:sourceObjectName", namespaces=OSTM_NS)
-                target = root.findtext("sf:targetObjectName", namespaces=OSTM_NS)
-                if not source or not target:
-                    continue
-                if source.endswith("__dll") and target.endswith("__dlm"):
-                    ds = root.findtext("sf:dataSpace", namespaces=OSTM_NS)
-                    if ds:
-                        data_spaces_seen.add(ds)
-                    else:
-                        no_dataspace += 1
-                    edges.append((source, target, ds or "(none in XML)"))
-
-        _ok(f"DLO→DMO edges found: {len(edges)}")
-
-        if data_spaces_seen:
-            _ok(f"Data spaces referenced in XML: {sorted(data_spaces_seen)}")
-        if no_dataspace:
-            _warn(
-                f"{no_dataspace}/{len(edges)} edges have no <dataSpace> field in XML. "
-                "The script will fall back to the value from the Dataspace SOQL query."
-            )
-
-        print()
-        print("  Edge list:")
-        for source, target, ds in edges:
-            print(f"    [{ds}] {source} → {target}")
 
 
 def check_calculated_insights(instance_url, token):
@@ -596,8 +370,7 @@ def main():
 
     token = check_auth(instance_url, client_id, client_secret)
     check_data_spaces(instance_url, token)
-    zip_bytes = check_metadata_retrieve(instance_url, token)
-    check_zip_contents(zip_bytes)
+    check_dlo_dmo_mappings(instance_url, token)
     check_calculated_insights(instance_url, token)
 
     _sep()

--- a/examples/push-ingestion/salesforce-data-cloud/test_push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/test_push_lineage.py
@@ -1,0 +1,463 @@
+"""
+Tests for push_lineage.py — Data 360 DLO->DMO + DMO->CIO lineage push.
+
+Focused on the read-only Data Cloud REST migration (mapping fetch, catalog-driven
+DMO enumeration, edge validation) plus the SSRF/parse/push helpers.
+
+Run:  pytest test_push_lineage.py -v
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+# Make the module importable without a real .env
+os.environ.setdefault("SF_ORG_URL", "https://test.my.salesforce.com")
+os.environ.setdefault("SF_CLIENT_ID", "fake_id")
+os.environ.setdefault("SF_CLIENT_SECRET", "fake_secret")
+os.environ.setdefault("MCD_INGEST_ID", "fake_ingest_id")
+os.environ.setdefault("MCD_INGEST_TOKEN", "fake_ingest_token")
+os.environ.setdefault("MCD_ID", "fake_mcd_id")
+os.environ.setdefault("MCD_TOKEN", "fake_mcd_token")
+os.environ.setdefault("MCD_RESOURCE_UUID", "00000000-0000-0000-0000-000000000001")
+
+import push_lineage as sut
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+def _resp(status=200, json_body=None, text="", content_type="application/json"):
+    r = MagicMock(spec=requests.Response)
+    r.status_code = status
+    r.headers = {"content-type": content_type}
+    r.text = text
+    if json_body is not None:
+        r.json.return_value = json_body
+    else:
+        r.json.side_effect = ValueError("no json")
+
+    def _raise():
+        if status >= 400:
+            err = requests.exceptions.HTTPError(str(status))
+            err.response = r
+            raise err
+
+    r.raise_for_status.side_effect = _raise
+    return r
+
+
+def _sf():
+    s = sut.SalesforceDataCloudService("https://test.my.salesforce.com", "cid", "secret")
+    s._token = "tok"
+    return s
+
+
+def _lineage():
+    return sut.SalesforceDataCloudLineageService(
+        resource_uuid="00000000-0000-0000-0000-000000000001",
+        ingest_key_id="ii", ingest_key_secret="is",
+        gql_key_id="gi", gql_key_secret="gs",
+    )
+
+
+# ── _parse_positive_int ──────────────────────────────────────────────────────
+class TestParsePositiveInt:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("X_INT", raising=False)
+        assert sut._parse_positive_int("X_INT", 7) == 7
+
+    def test_parses_env(self, monkeypatch):
+        monkeypatch.setenv("X_INT", "42")
+        assert sut._parse_positive_int("X_INT", 7) == 42
+
+    def test_rejects_zero(self, monkeypatch):
+        monkeypatch.setenv("X_INT", "0")
+        with pytest.raises(SystemExit):
+            sut._parse_positive_int("X_INT", 7)
+
+    def test_rejects_non_numeric(self, monkeypatch):
+        monkeypatch.setenv("X_INT", "abc")
+        with pytest.raises(SystemExit):
+            sut._parse_positive_int("X_INT", 7)
+
+
+# ── _is_retryable ────────────────────────────────────────────────────────────
+class TestIsRetryable:
+    def test_4xx_not_retryable(self):
+        err = requests.exceptions.HTTPError()
+        err.response = MagicMock(status_code=403)
+        assert sut._is_retryable(err) is False
+
+    def test_5xx_retryable(self):
+        err = requests.exceptions.HTTPError()
+        err.response = MagicMock(status_code=503)
+        assert sut._is_retryable(err) is True
+
+    def test_no_response_retryable(self):
+        assert sut._is_retryable(requests.exceptions.ConnectionError()) is True
+
+
+# ── _safe_snippet ────────────────────────────────────────────────────────────
+class TestSafeSnippet:
+    def test_redacts_long_token(self):
+        tok = "A" * 80
+        assert tok not in sut._safe_snippet(f"error: {tok}")
+        assert "[…]" in sut._safe_snippet(f"error: {tok}")
+
+    def test_truncates(self):
+        # Non-token text (spaces break the token regex) is truncated to max_len.
+        assert len(sut._safe_snippet("word " * 100)) == 200
+
+    def test_none_safe(self):
+        assert sut._safe_snippet(None) == ""
+
+    def test_short_text_unchanged(self):
+        assert sut._safe_snippet("bad request") == "bad request"
+
+
+# ── _parse_sql_inputs ────────────────────────────────────────────────────────
+class TestParseSqlInputs:
+    def test_extracts_dmo_and_cio(self):
+        sql = "SELECT * FROM Account__dlm JOIN Revenue__cio ON x"
+        assert sut._parse_sql_inputs(sql) == {"account__dlm", "revenue__cio"}
+
+    def test_lowercases(self):
+        assert sut._parse_sql_inputs("FROM ACCOUNT__DLM") == {"account__dlm"}
+
+    def test_excludes_self_reference(self):
+        sql = "SELECT * FROM Account__dlm, Self__cio"
+        assert sut._parse_sql_inputs(sql, cio_api_name="Self__cio") == {"account__dlm"}
+
+    def test_ignores_fields_and_non_objects(self):
+        # __c fields must not be captured
+        assert sut._parse_sql_inputs("SELECT Amount__c FROM Order__dlm") == {"order__dlm"}
+
+    def test_handles_subquery(self):
+        sql = "SELECT * FROM (SELECT id FROM Nested__dlm) t"
+        assert "nested__dlm" in sut._parse_sql_inputs(sql)
+
+    def test_empty(self):
+        assert sut._parse_sql_inputs("SELECT 1") == set()
+
+
+# ── SalesforceDataCloudService.token guard ────────────────────────────────────
+class TestTokenGuard:
+    def test_raises_before_auth(self):
+        s = sut.SalesforceDataCloudService("https://x.my.salesforce.com", "a", "b")
+        with pytest.raises(RuntimeError):
+            _ = s.token
+
+    def test_invalidate_clears_secret(self):
+        s = _sf()
+        s.invalidate_token()
+        assert s._token == ""
+        assert s.client_secret == ""
+
+
+# ── _fetch_dmo_mappings (no-retry branches) ───────────────────────────────────
+class TestFetchDmoMappings:
+    def test_404_returns_empty(self):
+        s = _sf()
+        with patch.object(sut.requests, "get", return_value=_resp(404)):
+            assert s._fetch_dmo_mappings("Account__dlm") == []
+
+    def test_200_returns_maps(self):
+        s = _sf()
+        body = {"objectSourceTargetMaps": [{"sourceEntityDeveloperName": "a__dll"}]}
+        with patch.object(sut.requests, "get", return_value=_resp(200, body)):
+            assert s._fetch_dmo_mappings("Account__dlm") == body["objectSourceTargetMaps"]
+
+    def test_200_missing_key_returns_empty(self):
+        s = _sf()
+        with patch.object(sut.requests, "get", return_value=_resp(200, {})):
+            assert s._fetch_dmo_mappings("Account__dlm") == []
+
+    def test_200_null_key_returns_empty(self):
+        s = _sf()
+        with patch.object(sut.requests, "get", return_value=_resp(200, {"objectSourceTargetMaps": None})):
+            assert s._fetch_dmo_mappings("Account__dlm") == []
+
+
+# ── fetch_dlo_dmo_edges (aggregation logic; mapping fetch mocked) ─────────────
+class TestFetchDloDmoEdges:
+    def test_empty_specs(self):
+        s = _sf()
+        assert s.fetch_dlo_dmo_edges([]) == []
+
+    def test_filters_and_builds_edges(self):
+        s = _sf()
+        s._fetch_dmo_mappings = MagicMock(return_value=[
+            {"sourceEntityDeveloperName": "acct__dll", "targetEntityDeveloperName": "acct__dlm"},
+            {"sourceEntityDeveloperName": "not_a_dll", "targetEntityDeveloperName": "acct__dlm"},  # dropped
+            {"sourceEntityDeveloperName": "acct__dll", "targetEntityDeveloperName": "wrong"},        # dropped
+        ])
+        edges = s.fetch_dlo_dmo_edges([("acct__dlm", "sales")])
+        assert edges == [{"source": "acct__dll", "target": "acct__dlm", "data_space": "sales"}]
+
+    def test_dedupes_case_insensitive(self):
+        s = _sf()
+        s._fetch_dmo_mappings = MagicMock(return_value=[
+            {"sourceEntityDeveloperName": "Acct__dll", "targetEntityDeveloperName": "Acct__dlm"},
+            {"sourceEntityDeveloperName": "acct__dll", "targetEntityDeveloperName": "acct__dlm"},
+        ])
+        edges = s.fetch_dlo_dmo_edges([("Acct__dlm", "sales")])
+        assert len(edges) == 1
+
+    def test_one_dmo_error_does_not_abort(self):
+        s = _sf()
+
+        def _maps(name):
+            if name == "bad__dlm":
+                raise RuntimeError("boom")
+            return [{"sourceEntityDeveloperName": "x__dll", "targetEntityDeveloperName": name}]
+
+        s._fetch_dmo_mappings = MagicMock(side_effect=_maps)
+        edges = s.fetch_dlo_dmo_edges([("bad__dlm", "s"), ("good__dlm", "s")])
+        assert edges == [{"source": "x__dll", "target": "good__dlm", "data_space": "s"}]
+
+    def test_404_empty_maps_skipped(self):
+        s = _sf()
+        s._fetch_dmo_mappings = MagicMock(return_value=[])
+        assert s.fetch_dlo_dmo_edges([("a__dlm", "s")]) == []
+
+
+# ── catalogued_dmos ──────────────────────────────────────────────────────────
+class TestCataloguedDmos:
+    def test_only_dlm_entries(self):
+        ls = _lineage()
+        catalog = {"a__dlm": "sales", "b__dll": "sales", "c__cio": "sales"}
+        assert ls.catalogued_dmos(catalog, "fb") == [("a__dlm", "sales")]
+
+    def test_str_entry_uses_space_list_entry_uses_fallback(self):
+        ls = _lineage()
+        catalog = {"a__dlm": "sales", "b__dlm": ["sales", "uk"]}
+        specs = dict(ls.catalogued_dmos(catalog, "FALLBACK"))
+        assert specs["a__dlm"] == "sales"
+        assert specs["b__dlm"] == "FALLBACK"
+
+
+# ── _resolve_catalog ─────────────────────────────────────────────────────────
+class TestResolveCatalog:
+    def test_missing_returns_none(self):
+        assert _lineage()._resolve_catalog({}, "x__dll") is None
+
+    def test_str_entry(self):
+        assert _lineage()._resolve_catalog({"x__dll": "sales"}, "X__dll") == "sales"
+
+    def test_list_prefers_match(self):
+        ls = _lineage()
+        assert ls._resolve_catalog({"x": ["a", "b"]}, "x", preferred_data_space="b") == "b"
+
+    def test_list_no_preferred_returns_none(self):
+        # Ambiguous multi-space entry, preferred not among them → unresolvable (skip, don't guess).
+        ls = _lineage()
+        assert ls._resolve_catalog({"x": ["a", "b"]}, "x") is None
+
+
+# ── validate_edges ───────────────────────────────────────────────────────────
+class TestValidateEdges:
+    def test_empty(self):
+        assert _lineage().validate_edges([], {"a": "b"}) == []
+
+    def test_both_present_same_space(self):
+        ls = _lineage()
+        catalog = {"a__dll": "sales", "a__dlm": "sales"}
+        edges = [{"source": "a__dll", "target": "a__dlm", "data_space": "sales"}]
+        assert ls.validate_edges(edges, catalog) == [
+            {"source": "a__dll", "target": "a__dlm", "data_space": "sales"}
+        ]
+
+    def test_target_missing_skipped(self):
+        ls = _lineage()
+        edges = [{"source": "a__dll", "target": "a__dlm", "data_space": "sales"}]
+        assert ls.validate_edges(edges, {"a__dll": "sales"}) == []
+
+    def test_source_missing_skipped(self):
+        ls = _lineage()
+        edges = [{"source": "a__dll", "target": "a__dlm", "data_space": "sales"}]
+        assert ls.validate_edges(edges, {"a__dlm": "sales"}) == []
+
+    def test_data_space_mismatch_skipped(self):
+        ls = _lineage()
+        catalog = {"a__dll": "uk", "a__dlm": "sales"}
+        edges = [{"source": "a__dll", "target": "a__dlm", "data_space": "sales"}]
+        assert ls.validate_edges(edges, catalog) == []
+
+    def test_ambiguous_multispace_target_skipped(self):
+        # DMO catalogued in two spaces; preliminary space matches neither → skip, don't guess.
+        ls = _lineage()
+        catalog = {"a__dll": "sales", "a__dlm": ["uk", "emea"]}
+        edges = [{"source": "a__dll", "target": "a__dlm", "data_space": "sales"}]
+        assert ls.validate_edges(edges, catalog) == []
+
+    def test_shared_dlo_resolves_to_dmo_space(self):
+        ls = _lineage()
+        catalog = {"a__dll": ["sales", "uk"], "a__dlm": "uk"}
+        edges = [{"source": "a__dll", "target": "a__dlm", "data_space": "sales"}]
+        result = ls.validate_edges(edges, catalog)
+        assert result == [{"source": "a__dll", "target": "a__dlm", "data_space": "uk"}]
+
+
+# ── _fetch_mc_catalog (GraphQL mocked) ───────────────────────────────────────
+class TestFetchMcCatalog:
+    def _page(self, edges, has_next=False, cursor=None):
+        return {"getTables": {"edges": edges, "pageInfo": {"hasNextPage": has_next, "endCursor": cursor}}}
+
+    def _node(self, ftid, dataset=None):
+        return {"node": {"fullTableId": ftid, "dataset": dataset}}
+
+    def test_filters_and_lowercases(self):
+        ls = _lineage()
+        ls._gql = MagicMock(return_value=self._page([
+            self._node("salesforce-data-cloud:default.Account__dlm", "default"),
+            self._node("snowflake:db.schema.other", "x"),          # wrong DB → skipped
+            self._node("salesforce-data-cloud:nodot", "x"),        # no "." → skipped
+        ]))
+        catalog = ls._fetch_mc_catalog()
+        assert catalog == {"account__dlm": "default"}
+
+    def test_dataset_fallback_to_fulltableid(self):
+        ls = _lineage()
+        ls._gql = MagicMock(return_value=self._page([
+            self._node("salesforce-data-cloud:sales.Order__dlm", None),
+        ]))
+        assert ls._fetch_mc_catalog() == {"order__dlm": "sales"}
+
+    def test_multi_space_accumulates_list(self):
+        ls = _lineage()
+        ls._gql = MagicMock(return_value=self._page([
+            self._node("salesforce-data-cloud:default.Acct__dll", "default"),
+            self._node("salesforce-data-cloud:uk.Acct__dll", "uk"),
+        ]))
+        assert ls._fetch_mc_catalog() == {"acct__dll": ["default", "uk"]}
+
+    def test_pagination(self):
+        ls = _lineage()
+        ls._gql = MagicMock(side_effect=[
+            self._page([self._node("salesforce-data-cloud:default.A__dlm", "default")], has_next=True, cursor="c1"),
+            self._page([self._node("salesforce-data-cloud:default.B__dlm", "default")]),
+        ])
+        catalog = ls._fetch_mc_catalog()
+        assert set(catalog) == {"a__dlm", "b__dlm"}
+        assert ls._gql.call_count == 2
+
+    def test_hasnext_but_null_cursor_breaks(self):
+        ls = _lineage()
+        ls._gql = MagicMock(return_value=self._page(
+            [self._node("salesforce-data-cloud:default.A__dlm", "default")], has_next=True, cursor=None))
+        catalog = ls._fetch_mc_catalog()
+        assert catalog == {"a__dlm": "default"}
+        assert ls._gql.call_count == 1  # did not loop forever
+
+
+# ── _validate_same_origin (SSRF guard) ────────────────────────────────────────
+class TestValidateSameOrigin:
+    def test_relative_path_prefixed(self):
+        s = _sf()
+        assert s._validate_same_origin("/services/data/x").startswith(
+            "https://test.my.salesforce.com/services/data")
+
+    def test_relative_not_slash_rejected(self):
+        with pytest.raises(RuntimeError):
+            _sf()._validate_same_origin("services/data/x")
+
+    def test_cross_host_rejected(self):
+        with pytest.raises(RuntimeError):
+            _sf()._validate_same_origin("https://evil.com/x")
+
+    def test_userinfo_host_rejected(self):
+        with pytest.raises(RuntimeError):
+            _sf()._validate_same_origin("https://test.my.salesforce.com@evil.com/x")
+
+    def test_non_https_rejected(self):
+        with pytest.raises(RuntimeError):
+            _sf()._validate_same_origin("http://test.my.salesforce.com/x")
+
+    def test_port_mismatch_rejected(self):
+        with pytest.raises(RuntimeError):
+            _sf()._validate_same_origin("https://test.my.salesforce.com:8443/x")
+
+    def test_same_origin_ok_and_strips_null_params(self):
+        s = _sf()
+        out = s._validate_same_origin(
+            "https://test.my.salesforce.com/x?definitionType=null&keep=1")
+        assert "definitionType" not in out
+        assert "keep=1" in out
+
+
+# ── parse_cio_edges ──────────────────────────────────────────────────────────
+class TestParseCioEdges:
+    def test_extracts_edges(self):
+        s = _sf()
+        cios = [{"apiName": "Rev__cio", "dataSpace": "sales",
+                 "expression": "SELECT * FROM Account__dlm JOIN Cost__cio"}]
+        edges = s.parse_cio_edges(cios)
+        assert {"source": "account__dlm", "target": "rev__cio", "data_space": "sales"} in edges
+        assert {"source": "cost__cio", "target": "rev__cio", "data_space": "sales"} in edges
+
+    def test_skips_non_cio(self):
+        s = _sf()
+        assert s.parse_cio_edges([{"apiName": "Account__dlm", "expression": "x"}]) == []
+
+    def test_skips_empty_expression(self):
+        s = _sf()
+        assert s.parse_cio_edges([{"apiName": "Rev__cio", "expression": ""}]) == []
+
+
+# ── get_dataspaces ───────────────────────────────────────────────────────────
+class TestGetDataspaces:
+    def test_returns_spaces(self):
+        s = _sf()
+        s._fetch_dataspaces_raw = MagicMock(return_value=_resp(200, {
+            "records": [{"DataSpaceApiName": "default"}, {"DataSpaceApiName": "uk"}]}))
+        assert s.get_dataspaces() == ["default", "uk"]
+
+    def test_403_falls_back(self):
+        s = _sf()
+        s._fetch_dataspaces_raw = MagicMock(return_value=_resp(403, {}, text="forbidden"))
+        assert s.get_dataspaces() == ["default"]
+
+    def test_exception_falls_back(self):
+        s = _sf()
+        s._fetch_dataspaces_raw = MagicMock(side_effect=requests.exceptions.ConnectionError())
+        assert s.get_dataspaces() == ["default"]
+
+    def test_empty_records_falls_back(self):
+        s = _sf()
+        s._fetch_dataspaces_raw = MagicMock(return_value=_resp(200, {"records": []}))
+        assert s.get_dataspaces() == ["default"]
+
+
+# ── push_edges (IngestionService mocked) ──────────────────────────────────────
+class TestPushEdges:
+    def _edges(self, n):
+        return [{"source": f"s{i}__dll", "target": f"t{i}__dlm", "data_space": "sales"} for i in range(n)]
+
+    def test_builds_lineage_events_and_batches(self, monkeypatch):
+        monkeypatch.setattr(sut, "INGEST_BATCH_SIZE", 2)
+        with patch.object(sut, "IngestionService") as MIS, \
+             patch.object(sut, "Client"), patch.object(sut, "Session"):
+            MIS.return_value.extract_invocation_id.side_effect = ["inv-1", "inv-2"]
+            ls = _lineage()
+            captured = []
+            ls._send_batch = MagicMock(side_effect=lambda svc, ev: captured.append(ev) or "resp")
+            ids = ls.push_edges(self._edges(3), "run1")
+        assert ids == ["inv-1", "inv-2"]           # 3 edges / batch size 2 → 2 batches
+        assert len(captured) == 2
+        first = captured[0][0]
+        assert first.destination.type == "TABLE"
+        assert first.destination.database == "salesforce-data-cloud"
+        assert first.destination.schema == "sales"
+        assert first.destination.name == "t0__dlm"
+        assert first.sources[0].name == "s0__dll"
+
+    def test_failure_saves_and_raises(self, monkeypatch):
+        monkeypatch.setattr(sut, "INGEST_BATCH_SIZE", 500)
+        with patch.object(sut, "IngestionService"), \
+             patch.object(sut, "Client"), patch.object(sut, "Session"), \
+             patch.object(sut, "_save_failed_edges", return_value="/tmp/failed.json") as save:
+            ls = _lineage()
+            ls._send_batch = MagicMock(side_effect=RuntimeError("push boom"))
+            with pytest.raises(RuntimeError, match="failed to push"):
+                ls.push_edges(self._edges(2), "run1")
+            save.assert_called_once()

--- a/examples/push-ingestion/salesforce-data-cloud/test_push_lineage.py
+++ b/examples/push-ingestion/salesforce-data-cloud/test_push_lineage.py
@@ -140,6 +140,18 @@ class TestParseSqlInputs:
         assert sut._parse_sql_inputs("SELECT 1") == set()
 
 
+# ── _asset_type ──────────────────────────────────────────────────────────────
+class TestAssetType:
+    def test_dlo_is_table(self):
+        assert sut._asset_type("Account_Home__dll") == "TABLE"
+
+    def test_dmo_is_view(self):
+        assert sut._asset_type("ssot__Account__dlm") == "VIEW"
+
+    def test_cio_is_view(self):
+        assert sut._asset_type("Revenue__cio") == "VIEW"
+
+
 # ── SalesforceDataCloudService.token guard ────────────────────────────────────
 class TestTokenGuard:
     def test_raises_before_auth(self):
@@ -445,10 +457,12 @@ class TestPushEdges:
         assert ids == ["inv-1", "inv-2"]           # 3 edges / batch size 2 → 2 batches
         assert len(captured) == 2
         first = captured[0][0]
-        assert first.destination.type == "TABLE"
+        # objectType must match the catalog: __dlm target -> VIEW, __dll source -> TABLE
+        assert first.destination.type == "VIEW"
         assert first.destination.database == "salesforce-data-cloud"
         assert first.destination.schema == "sales"
         assert first.destination.name == "t0__dlm"
+        assert first.sources[0].type == "TABLE"
         assert first.sources[0].name == "s0__dll"
 
     def test_failure_saves_and_raises(self, monkeypatch):


### PR DESCRIPTION
## What & why

Migrates the DLO→DMO lineage extraction in the `salesforce-data-cloud` push example from the **SOAP Metadata API** (`retrieve` of `ObjectSourceTargetMap`) to the **read-only Data Cloud REST endpoint** `/ssot/data-model-object-mappings`.

This removes the **`Modify Metadata Through Metadata API Functions`** run-as permission requirement. DLO→DMO lineage is now read entirely with standard Data Cloud read access — resolving the platform-team objection to granting a write-capable Metadata API permission just to read lineage. Mirrors the change Federico shipped in the native connector.

## Changes

**`push_lineage.py`**
- Removes SOAP machinery: `_soap_post`, `listMetadata`/`retrieve`/`checkRetrieveStatus` poll loop, ZIP extraction, and `defusedxml` parsing.
- Catalog-first flow: enumerate catalogued DMOs from the MC catalog, issue one read-only GET per DMO (parallelized via `MAPPING_MAX_WORKERS`), filter source `__dll` / target `__dlm`, dedupe, and validate against the same catalog (`dataset` field remains authoritative for data space).
- `404 NOT_FOUND` from the mapping endpoint = that DMO has no source mappings → skipped silently.

**`sf_diagnostic.py`**
- Replaces the SOAP retrieve check with a read-only mapping probe over a bounded set of DMOs (`DIAG_MAX_DMOS`, default 150).

**Docs / config**
- `README`, `TROUBLESHOOTING`, `.env.example`: `METADATA_*` tuning vars → `MAPPING_MAX_WORKERS`; permissions sections now state no Metadata API / "Modify Metadata" permission is required for DLO→DMO. DMO→CIO path (Steps 5–8) unchanged.

## Validation

Live-tested against a dev org: **22 DLO→DMO edges**, matching the SOAP-vs-REST diff (22/22). Diagnostic run reports all Salesforce APIs accessible. Net −525 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)